### PR TITLE
Makefile: add a 'shell' target to ease dev on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 ARG GO_VERSION=1.25.1
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
+ARG DOCKER_VERSION=28.4.0
+ARG DOCKER_IMAGE="docker:${DOCKER_VERSION}-cli"
 
 FROM ${GOLANG_IMAGE} AS base
 
@@ -131,3 +133,33 @@ COPY --from=initrd-build /build/nerdbox-initrd /nerdbox-initrd
 
 FROM scratch AS shim
 COPY --from=shim-build /build/containerd-shim-nerdbox-v1 /containerd-shim-nerdbox-v1
+
+FROM "${DOCKER_IMAGE}" AS docker-cli
+
+FROM "${GOLANG_IMAGE}" AS dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM debian:${BASE_DEBIAN_DISTRO} AS dev
+ARG CONTAINERD_VERSION=2.1.4
+ARG TARGETARCH
+
+# Install build dependencies
+RUN --mount=type=cache,sharing=locked,id=dev-aptlib,target=/var/lib/apt \
+    --mount=type=cache,sharing=locked,id=dev-aptcache,target=/var/cache/apt \
+        apt-get update && apt-get install -y git make wget
+
+RUN wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local/bin --strip-components=1 -xf containerd-${CONTAINERD_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    rm containerd-${CONTAINERD_VERSION}-linux-${TARGETARCH}.tar.gz
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+
+COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
+
+RUN << EOT
+    set -e
+    echo 'export PATH=$(pwd)/_output:$PATH' >> /etc/profile
+EOT
+
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ GO_BUILD_FLAGS ?=
 GO_LDFLAGS := -ldflags '$(EXTRA_LDFLAGS)'
 GO_STATIC_LDFLAGS := -ldflags '-extldflags "-static" $(EXTRA_LDFLAGS)'
 
+MODULE_NAME=$(shell go list -m)
 API_PACKAGES=$(shell ($(GO) list ${GO_TAGS} ./... | grep /api/ ))
 
-.PHONY: clean all generate protos check-protos check-api-descriptors proto-fmt
+.PHONY: clean all generate protos check-protos check-api-descriptors proto-fmt shell
 
 all:
 	$(BUILDX) bake
@@ -96,3 +97,14 @@ FORCE:
 
 clean:
 	rm -rf _output
+
+shell:
+	@echo "$(WHALE) $@"
+	@$(BUILDX) bake dev
+	@docker run --rm -it --privileged \
+		--name nerdbox-dev \
+		-v ./:/go/src/$(MODULE_NAME) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-w /go/src/$(MODULE_NAME) \
+		$(DOCKER_EXTRA_ARGS) \
+		nerdbox-dev

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -58,3 +58,9 @@ target "shim" {
 group "default" {
     targets = ["kernel", "initrd", "shim"]
 }
+
+target "dev" {
+  inherits = ["_common"]
+  target = "dev"
+  output = ["type=image,name=nerdbox-dev"]
+}


### PR DESCRIPTION
The dev env is pretty much done I think, but I can't start a container:

```
# ctr run -t --rm --runtime io.containerd.nerdbox.v1 docker.io/library/alpine:latest test /bin/sh
ctr: failed to create shim task: mount source: "overlay", target: "/run/containerd/io.containerd.runtime.v2.task/default/test/rootfs", fstype: overlay, flags: 0, data: "workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/work,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/fs,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs,index=off", err: invalid argument
```