### PR TITLE
internal/vm/libkrun: set kernel format based on arch

### DIFF
--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -86,7 +86,7 @@ func (vm *vmcontext) SetKernel(kernelPath string, initrdPath string, kernelCmdli
 
 	// TODO: Support different kernel formats
 	var format uint32
-	if runtime.GOOS == "darwin" {
+	if runtime.GOARCH == "arm64" {
 		format = kernelFormatRaw
 	} else {
 		format = kernelFormatElf


### PR DESCRIPTION
libkrun checks the architecture, and not the platform, to determine which kernel formats are supported. Use the 'raw' format on arm64.

See https://github.com/containers/libkrun/blob/5197e451eb83be80d1ef0a81626c9359972d35e7/src/vmm/src/builder.rs#L1007