### PR TITLE
Update readme instructions for containerd

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ mounted on the host and passed to the VM via virtio-fs. For Mac OS, the erofs
 snapshotter is required. Currently, to run on Mac OS, this requires using a
 development branch of containerd with the changes targed for the containerd 2.2
 release. Use the following tag to build containerd for Mac OS:
-https://github.com/dmcgowan/containerd/tree/v2.2.0-beta.0-erofs-darwin.3
+https://github.com/dmcgowan/containerd/tree/v2.2.0-beta.0-erofs-darwin.4
 
 #### Enabling erofs in containerd config toml
 
@@ -65,6 +65,7 @@ unpacking linux/arm64 images.
     [[plugins."io.containerd.transfer.v1.local".unpack_config]]
       platform = "linux/arm64"
       snapshotter = "erofs"
+      differ = "erofs"
 ```
 
 #### Add default size to snapshotter


### PR DESCRIPTION
Use the latest development tag to ensure snapshots are properly cleanedup. Add `differ` field to unpack, which ensure the erofs differ is used on Linux.