### PR TITLE
Fix parse command to ensure args are used

### DIFF
--- a/cmd/vminitd/main.go
+++ b/cmd/vminitd/main.go
@@ -69,7 +69,7 @@ func main() {
 	if len(args) > 0 && args[0] == "tsi_hijack" {
 		args = args[1:]
 	}
-	flag.Parse()
+	flag.CommandLine.Parse(args)
 
 	/*
 		c, err := os.OpenFile("/dev/console", os.O_WRONLY, 0644)


### PR DESCRIPTION
The `flag.Parse()` should not be directly used as the `tsi_hijack` will break the parsing. Previously it was doing both and one was removed as duplicate, it should be `flag.Parse()` removed.