### PR TITLE
Add a 5s timeout for VM startup

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -224,6 +224,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		return nil, errgrpc.ToGRPC(err)
 	}
 	bootTime := time.Since(prestart)
+	log.G(ctx).WithField("bootTime", bootTime).Debug("VM started")
 
 	vmc, err := s.client()
 	if err != nil {


### PR DESCRIPTION
When something goes wrong during VM startup and libkrun panics, the `ctr` process becomes unresponsive, the shim process has to be manually killed, containerd needs a restart, and the container has to be rm'd from containerd.

So, add a timeout on VM startup. The tidy-up happens and it's possible to start a new vm/container.

`v.vmc.Start()` doesn't return, so its goroutine leaks. Perhaps an issue with the way we're calling the C function.

It's a hardcoded 5s timeout, maybe it should be configurable somehow - but this'll improve things.

From a run where I passed a nonexistent socket in `io.containerd.nerdbox.network.0` ...

```
[    0.039971] virtio_blk virtio4: [vdb] 17256 512-byte logical blocks (8.84 MB/8.43 MiB)
[    0.040276] tun: Universal TUN/TAP device driver, 1.6
[2025-10-14T14:53:40Z ERROR devices::virtio::net::device] Error activating virtio-net (eth0) backend: Binding(EROFS)

thread 'fc_vcpu 0' panicked at src/devices/src/virtio/mmio.rs:298:26:
Failed to activate device: BadActivate
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: devices::virtio::mmio::MmioTransport::set_device_status
   4: vmm::macos::vstate::Vcpu::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
[    0.073629] Freeing initrd memory: 5048K
time="2025-10-14T15:53:45.462445000+01:00" level=warning msg="Timeout while waiting for VM to start" runtime=io.containerd.nerdbox.v1 timeout=5s
time="2025-10-14T15:53:45.464161000+01:00" level=info msg="deleting task" exec= id=test runtime=io.containerd.nerdbox.v1
ERRO[2025-10-14T15:53:45.464394000+01:00] failed to delete task                         error="rpc error: code = FailedPrecondition desc = vm not running: failed precondition" id=test
time="2025-10-14T15:53:45.464832000+01:00" level=info msg=shutdown id=test runtime=io.containerd.nerdbox.v1
INFO[2025-10-14T15:53:45.465561000+01:00] shim disconnected                             id=test namespace=default
INFO[2025-10-14T15:53:45.465667000+01:00] cleaning up after shim disconnected           id=test namespace=default
INFO[2025-10-14T15:53:45.465784000+01:00] cleaning up dead shim                         id=test namespace=default
ERRO[2025-10-14T15:53:45.472080000+01:00] failed to delete dead shim                    cmd="/Users/robm/git/nerdbox/_output/containerd-shim-nerdbox-v1 -namespace default -address /Users/robm/.containerd/var/run/containerd/containerd.sock -publish-binary /Users/robm/git/containerd/bin/containerd -id test -bundle /Users/robm/.containerd/var/run/containerd/io.containerd.runtime.v2.task/default/test -debug delete" error="fork/exec /Users/robm/git/nerdbox/_output/containerd-shim-nerdbox-v1: no such file or directory" id=test namespace=default
WARN[2025-10-14T15:53:45.472290000+01:00] failed to clean up after shim disconnected    error=": fork/exec /Users/robm/git/nerdbox/_output/containerd-shim-nerdbox-v1: no such file or directory" id=test namespace=default
DEBU[2025-10-14T15:53:45.478728000+01:00] remove snapshot                               key=test snapshotter=erofs
DEBU[2025-10-14T15:53:45.925858000+01:00] schedule snapshotter cleanup                  snapshotter=erofs
DEBU[2025-10-14T15:53:45.948056000+01:00] removed snapshot                              key=default/88/test snapshotter=erofs
```