### PR TITLE
vminit: fix panic in waitForCtrNetConnect

### DIFF
--- a/internal/vminit/task/service.go
+++ b/internal/vminit/task/service.go
@@ -857,7 +857,7 @@ func (s *service) waitForCtrNetConnect(ctx context.Context, id string) error {
 	wait, ok := s.ctrNetConnectWaiters[id]
 	delete(s.ctrNetConnectWaiters, id)
 	s.mu.Unlock()
-	if !ok {
+	if !ok || wait == nil {
 		return nil
 	}
 


### PR DESCRIPTION
`s.ctrNetConnectWaiters` contains a nil entry if there's a container is started with no networking config specified.