### PR TITLE
README.md: /var/run/containerd is not changeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,8 @@ may need to be updated to run containerd as a non-root user.
 
 By default, ensure `/var/lib/containerd` and `/var/run/containerd` are owned by
 the user. Alternatively, the config can be updated to reference directories
-writable by the user. Update the containerd config toml file.
-
-```toml
-root = '/var/lib/containerd'
-state = '/var/run/containerd'
-```
+writable by the user, but updating the config to use user-writable directories is
+currently not functional due to the issue [containerd#12444](https://github.com/containerd/containerd/issues/12444).
 
 Also ensure that the grpc socket is owned by the non root user.
 


### PR DESCRIPTION
The path of /var/run/containerd is hard-coded in pkg/shim and not changeable at the moment.

See
- containerd/containerd#12444