### PR TITLE
Add examples/macos/config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ snapshotter is required. Currently, to run on macOS, this requires using
 containerd 2.2. Use containerd v2.2.0-rc.0 or later:
 https://github.com/containerd/containerd/releases/tag/v2.2.0-rc.0
 
+See [`./examples/macos/config.toml`](./examples/macos/config.toml) for
+how to configure containerd on macOS.
+
+<details>
+<summary>Manual configuration</summary>
+
 #### Enabling erofs in containerd config toml
 
 If you don't have a containerd config file yet, generate one with:
@@ -82,6 +88,18 @@ unpacking linux/arm64 images.
       differ = "erofs"
 ```
 
+#### Add differ options
+
+nerdctl needs the following configuration, as it does not use the transfer service yet.
+
+<!-- https://github.com/containerd/nerdctl/issues/4570#issuecomment-3474216920 -->
+
+```toml
+  [plugins.'io.containerd.service.v1.diff-service']
+    default = ['erofs', 'walking']
+    sync_fs = false
+```
+
 #### Add default size to snapshotter
 
 ```toml
@@ -89,6 +107,8 @@ unpacking linux/arm64 images.
     default_size = "64M"
 
 ```
+
+</details>
 
 ### Running
 

--- a/examples/macos/config.toml
+++ b/examples/macos/config.toml
@@ -1,0 +1,34 @@
+# An example config.toml for running containerd on macOS hosts.
+# Assumes UID 501 and GID 20.
+
+# Usage:
+#
+#   sudo mkdir -p /var/lib/containerd /var/run/containerd
+#   sudo chown 501:20 /var/lib/containerd /var/run/containerd
+#   PATH=/opt/homebrew/opt/e2fsprogs/sbin:$PATH containerd -c config.toml
+
+version = 3
+[grpc]
+  # The path of /var/run/containerd is still not changeable
+  # https://github.com/containerd/containerd/issues/12444
+  address = '/var/run/containerd/containerd.sock'
+  uid = 501
+  gid = 20
+
+[plugins.'io.containerd.snapshotter.v1.erofs']
+  default_size = "64M"
+
+[plugins.'io.containerd.differ.v1.erofs']
+  mkfs_options = ['-b4096']
+
+[plugins.'io.containerd.transfer.v1.local']
+  [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+    platform = "linux/arm64"
+    snapshotter = "erofs"
+    differ = "erofs"
+
+# needed for nerdctl
+# https://github.com/containerd/nerdctl/issues/4570#issuecomment-3474216920
+[plugins.'io.containerd.service.v1.diff-service']
+  default = ['erofs', 'walking']
+  sync_fs = false


### PR DESCRIPTION
Add an example config for running containerd on macOS. See the comment lines for the usage.