### PR TITLE
shim: macos: remove unneeded entitlement

### DIFF
--- a/cmd/containerd-shim-nerdbox-v1/containerd-shim-nerdbox-v1.entitlements
+++ b/cmd/containerd-shim-nerdbox-v1/containerd-shim-nerdbox-v1.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.security.hypervisor</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validationr</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The `disable-library-validation` entitlement has a typo — an extra 'r' at the end — proving that it's not needed. Remove it.