### PR TITLE
bakefile: add the ability to cross-compile the shim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,11 +95,13 @@ ARG GO_DEBUG_GCFLAGS
 ARG GO_GCFLAGS
 ARG GO_BUILD_FLAGS
 ARG GO_LDFLAGS
+ARG TARGETOS
+ARG TARGETARCH
 ARG TARGETPLATFORM
 
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=shim-build-$TARGETPLATFORM \
-    go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/containerd-shim-nerdbox-v1 ${GO_LDFLAGS} -tags 'no_grpc' ./cmd/containerd-shim-nerdbox-v1
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/containerd-shim-nerdbox-v1 ${GO_LDFLAGS} -tags 'no_grpc' ./cmd/containerd-shim-nerdbox-v1
 
 FROM base AS vminit-build
 


### PR DESCRIPTION
This allows to build the containerd-shim-nerdbox-v1 binary for different platforms by using the Bake file remotely.