### PR TITLE
add /usr/local/lib64 to default search path

### DIFF
--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -60,7 +60,7 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 		initrdPath string
 	)
 	if len(p2) == 0 {
-		p2 = []string{"/usr/local/lib", "/usr/lib", "/lib"}
+		p2 = []string{"/usr/local/lib", "/usr/local/lib64", "/usr/lib", "/lib"}
 	}
 	sharedName := "libkrun.so"
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
Add `/usr/local/lib64` to default search path for libkrun, as on linux that is the default installation path  as per https://github.com/containers/libkrun/blob/da31a4aacdf7101527a94298fbaff311195338fc/Makefile#L90