### PR TITLE
Set libkrun log level to warn

### DIFF
--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -110,7 +110,7 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 
 	var ret int32
 	setLogging.Do(func() {
-		ret = lib.InitLog(os.Stderr.Fd(), uint32(debugLevel), 0, 0)
+		ret = lib.InitLog(os.Stderr.Fd(), uint32(warnLevel), 0, 0)
 	})
 	if ret != 0 {
 		return nil, fmt.Errorf("krun_init_log failed: %d", ret)

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -47,7 +47,7 @@ const (
 type logLevel uint32
 
 const (
-	debugLevel logLevel = 1
+	warnLevel logLevel = 2
 )
 
 type vmcontext struct {


### PR DESCRIPTION
I was having issues running nerdbox on macos with nerdctl and couldn't find a root cause until I increased the log level:
```
[2025-11-17T23:27:50Z WARN  devices::virtio::vsock::muxer_thread] Failed to create listening proxy at "../../../../../../../var/run/containerd/io.containerd.runtime.v2.task/default/ad8b7eb45b55b08b8732715f51a440aa0505f371033c778c99bcd98984599107/vm/run_vminitd.sock": CreatingSocket(ENAMETOOLONG)
[2025-11-17T23:27:50Z WARN  devices::virtio::vsock::muxer_thread] Failed to create listening proxy at "../../../../../../../var/run/containerd/io.containerd.runtime.v2.task/default/ad8b7eb45b55b08b8732715f51a440aa0505f371033c778c99bcd98984599107/vm/streaming.sock": CreatingSocket(ENAMETOOLONG)
```

This PR sets the log level to warn by default.

The previous level was labeled as debug, but it was actually setting [error](https://github.com/containers/libkrun/blob/da31a4aacdf7101527a94298fbaff311195338fc/src/libkrun/src/lib.rs#L412-L421). libkrun's debug log level is a lot, so I don't think it would be useful to enable by default.
