### PR TITLE
Add EROFS flatten device support (fsmerge feature)

### DIFF
--- a/internal/erofs/vmdk.go
+++ b/internal/erofs/vmdk.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	max2GbExtentSectors = 0x80000000 >> 9
+	sectorsPerTrack     = 63
+	numberHeads         = 16
+	subformat           = "twoGbMaxExtentFlat"
+	adapterType         = "ide"
+	hwVersion           = "4"
+)
+
+// vmdkDescAddExtent writes extent lines to the writer.
+// Each extent line follows the format: RW <count> FLAT "<filename>" <offset>
+func vmdkDescAddExtent(w io.Writer, sectors uint64, filename string, offset uint64) error {
+	for sectors > 0 {
+		count := min(sectors, max2GbExtentSectors)
+
+		_, err := fmt.Fprintf(w, "RW %d FLAT \"%s\" %d\n", count, filename, offset)
+		if err != nil {
+			return err
+		}
+		offset += count
+		sectors -= count
+	}
+	return nil
+}
+
+func DumpVMDKDescriptor(w io.Writer, cid uint32, devices []string) error {
+	parentCID := uint32(0xffffffff)
+
+	_, err := fmt.Fprintf(w, `# Disk DescriptorFile
+version=1
+CID=%08x
+parentCID=%08x
+createType="%s"
+
+# Extent description
+`, cid, parentCID, subformat)
+	if err != nil {
+		return err
+	}
+
+	totalSectors := uint64(0)
+
+	for _, d := range devices {
+		fi, err := os.Stat(d)
+		if err != nil {
+			return err
+		}
+		sectors := uint64(fi.Size()) >> 9
+		err = vmdkDescAddExtent(w, sectors, d, 0)
+		if err != nil {
+			return err
+		}
+		totalSectors += sectors
+	}
+
+	cylinders := (totalSectors + sectorsPerTrack*numberHeads - 1) / (sectorsPerTrack * numberHeads)
+	_, err = fmt.Fprintf(w, `
+
+# The Disk Data Base
+#DDB
+
+ddb.virtualHWVersion = "%s"
+ddb.geometry.cylinders = "%d"
+ddb.geometry.heads = "%d"
+ddb.geometry.sectors = "63"
+ddb.adapterType = "%s"
+`, hwVersion, cylinders, numberHeads, adapterType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DumpVMDKDescriptorToFile(vmdkdesc string, cid uint32, devices []string) error {
+	f, err := os.Create(vmdkdesc)
+	if err != nil {
+		return err
+	}
+	err = DumpVMDKDescriptor(f, cid, devices)
+	f.Close()
+	return err
+}

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -172,7 +172,11 @@ func (v *vmInstance) AddDisk(ctx context.Context, blockID, mountPath string, opt
 		o(&mc)
 	}
 
-	if err := v.vmc.AddDisk(blockID, mountPath, mc.Readonly); err != nil {
+	var dskFmt uint32 = 0
+	if mc.Vmdk {
+		dskFmt = 2
+	}
+	if err := v.vmc.AddDisk2(blockID, mountPath, dskFmt, mc.Readonly); err != nil {
 		return fmt.Errorf("failed to add disk at '%s': %w", mountPath, err)
 	}
 

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -156,6 +156,17 @@ func (vmc *vmcontext) AddDisk(blockID, path string, readonly bool) error {
 	return nil
 }
 
+func (vmc *vmcontext) AddDisk2(blockID, path string, diskFmt uint32, readonly bool) error {
+	if vmc.lib.AddDisk2 == nil {
+		return fmt.Errorf("libkrun not loaded")
+	}
+	ret := vmc.lib.AddDisk2(vmc.ctxID, blockID, path, diskFmt, readonly)
+	if ret != 0 {
+		return fmt.Errorf("krun_add_disk2 failed: %d", ret)
+	}
+	return nil
+}
+
 func (vmc *vmcontext) AddNIC(endpoint string, mac net.HardwareAddr, mode vm.NetworkMode, features, flags uint32) error {
 	if vmc.lib.AddNetUnixgram == nil || vmc.lib.AddNetUnixstream == nil {
 		return fmt.Errorf("libkrun not loaded")
@@ -243,6 +254,7 @@ type libkrun struct {
 	SetGvproxyPath     func(ctxID uint32, path string) int32                                                  `C:"krun_set_gvproxy_path"`
 	SetNetMac          func(ctxID uint32, mac []uint8) int32                                                  `C:"krun_set_net_mac"`
 	AddDisk            func(ctxID uint32, blockId, path string, readonly bool) int32                          `C:"krun_add_disk"`
+	AddDisk2           func(ctxID uint32, blockId, path string, diskFmt uint32, readonly bool) int32          `C:"krun_add_disk2"`
 	AddNetUnixstream   func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32     `C:"krun_add_net_unixstream"`
 	AddNetUnixgram     func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32     `C:"krun_add_net_unixgram"`
 

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -49,6 +49,7 @@ func WithInitArgs(args ...string) StartOpt {
 
 type MountConfig struct {
 	Readonly bool
+	Vmdk     bool
 }
 
 type MountOpt func(*MountConfig)
@@ -73,5 +74,11 @@ type Instance interface {
 func WithReadOnly() MountOpt {
 	return func(o *MountConfig) {
 		o.Readonly = true
+	}
+}
+
+func WithVmdk() MountOpt {
+	return func(o *MountConfig) {
+		o.Vmdk = true
 	}
 }


### PR DESCRIPTION
Fix #30
~~Depends on https://github.com/containerd/containerd/pull/12374~~ merged
~~Depends on https://github.com/XanClic/imago/pull/1~~ merged
~~Depends on https://github.com/containers/libkrun/pull/474~~ merged

So that hundreds of sub-blobs (container image layers) can be merged into one block device to avoid having too many block devices plugging into a VM.

Launching wordpress with fsmerge-enabled EROFS snapshotter:
<img width="3014" height="562" alt="image" src="https://github.com/user-attachments/assets/abeb4df2-46b1-410e-8764-1ae7189f40fc" />

<img width="2278" height="272" alt="image" src="https://github.com/user-attachments/assets/62fafa95-9563-40d6-8a93-8a0c383e05d5" />