### PR TITLE
ci: bump Go 1.25.5

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.24.8"
+    default: "stable"
     description: "Go version to install"
 
 runs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # Build the Linux kernel, initrd ,and containerd shim for running nerbox
 
 ARG XX_VERSION=1.9.0
-ARG GO_VERSION=1.25.1
+ARG GO_VERSION=1.25.5
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 ARG GOLANGCI_LINT_VERSION=2.7.2

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/containerd/nerdbox
 
 go 1.24.3
 
-toolchain go1.24.4
-
 require (
 	github.com/containerd/cgroups/v3 v3.1.2
 	github.com/containerd/console v1.0.5


### PR DESCRIPTION
* Dropped the Go toolchain keyword
* Updated install-go to be stable (used in CI to run project checks)
* Bumped Go in Dockerfile to Go 1.25.5