### PR TITLE
fix racy connection to vm/run_vminitd.sock

### DIFF
--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -305,7 +305,8 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 		if _, err := os.Stat(socketPath); err == nil {
 			conn, err = net.Dial("unix", socketPath)
 			if err != nil {
-				return fmt.Errorf("failed to connect to TTRPC server: %w", err)
+				log.G(ctx).WithError(err).Debugf("VM socket exists, but can't connect yet. Retrying in %s...", d)
+				continue
 			}
 			conn.SetReadDeadline(time.Now().Add(d))
 			if err := ttrpcutil.PingTTRPC(conn); err != nil {


### PR DESCRIPTION
When starting a container, the host-side shim tries to connect to a UNIX socket created by libkrun to forward vsock connections. This socket is used by the shim to communicate with the vminit process running inside the VM.

The host-side shim is assuming that it can connect to the UNIX socket as soon as the socket can be stat'd, but this leaves a small race window where the socket file is created by the `bind` syscall but not listened to yet.