### PR TITLE
Use relative path for vm state directory

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -207,8 +207,12 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	}
 	b.AddExtraFile(nwcfg.Filename, nwJSON)
 
-	vmState := filepath.Join(r.Bundle, "vm")
-	if err := os.Mkdir(vmState, 0700); err != nil {
+	// vmState directory should be a path under the current working directory, not specific to a single bundle
+	vmState, err := filepath.Abs("vm")
+	if err != nil {
+		return nil, errgrpc.ToGRPCf(err, "failed to get absolute path for vm state directory")
+	}
+	if err := os.MkdirAll(vmState, 0700); err != nil {
 		return nil, errgrpc.ToGRPCf(err, "failed to create vm state directory %q", vmState)
 	}
 	vmi, err := s.vmInstance(ctx, vmState)


### PR DESCRIPTION
Prevents socket paths becoming too long when the resolved current working directory differs from the given bundle path, for example current working directory resolving to `/private/var/...` but the bundle directory reported as `/var/...`. The vm state directory does not need to be associated with a specific bundle and the working directory assigned to the shim is sufficient as the parent for the vm state directory.