### PR TITLE
Remove buf update from make protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ generate: protos
 
 protos:
 	@echo "$(WHALE) $@"
-	@(cd ${ROOTDIR}/api && buf dep update)
 	@(cd ${ROOTDIR}/api && PATH="${ROOTDIR}/bin:${PATH}" buf generate)
 	@(cd ${ROOTDIR}/api && buf build --exclude-imports -o next.txtpb)
 	go-fix-acronym -w -a '^Os' $(shell find api/ -name '*.pb.go')


### PR DESCRIPTION
The protos target gets run during CI to validate there are not ungenerated proto changes. The updates can change at any point if buf dependencies are updated at this point. While it is unlikely they will change often, they should change intentially, just as go dependencies would happen.