### PR TITLE
pass VM CPU and RAM spec through OCI annotations

### DIFF
--- a/docs/ctr-networking.md
+++ b/docs/ctr-networking.md
@@ -3,7 +3,7 @@
 ## Connecting to VM networks
 
 Containers can be connected to networks the VM that have been defined via the
-`io.containerd.nerdbox.network.*` annotation, see [vm-networking](vm-networking.md).
+`io.containerd.nerdbox.network.*` annotation, see [VM Configuration](vm-configuration.md#networking).
 
 Each `io.containerd.nerdbox.ctr.network` annotation describes a single network
 connection.

--- a/docs/vm-configuration.md
+++ b/docs/vm-configuration.md
@@ -1,6 +1,15 @@
-# VM Networking
+# VM Configuration
 
-## TSI
+## Resources
+
+VM resources can be configured through the following OCI annotations:
+
+- `io.containerd.nerdbox.resources.cpu`: Number of vCPUs (default: 2)
+- `io.containerd.nerdbox.resources.memory`: Memory in MiB (default: 2048)
+
+## Networking
+
+### TSI
 
 By default, nerdbox creates microVMs with no network interface set up. In this
 case, VMs get connectivity through TSI (i.e. Transparent Socket Impersonation).
@@ -15,7 +24,7 @@ These patches automatically translate socket syscalls made for socket family
 AF_INET, and socket types SOCK_STREAM and SOCK_DGRAM, into AF_TSI. As such,
 this networking mode doesn't support IPv6 connections, and ICMP protocol.
 
-## External network providers
+### External network providers
 
 Network interfaces can be attached to the VM by specifying the OCI annotations
 `io.containerd.nerdbox.network.*`. These annotations are CSV-encoded strings

--- a/internal/shim/task/resources_config.go
+++ b/internal/shim/task/resources_config.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/containerd/nerdbox/internal/shim/task/bundle"
+	"github.com/containerd/nerdbox/internal/vm"
+)
+
+const (
+	resourcesAnnotation = "io.containerd.nerdbox.resources"
+	cpuAnnotation       = resourcesAnnotation + ".cpu"
+	memAnnotation       = resourcesAnnotation + ".memory"
+)
+
+type resourceConfig struct {
+	cpu uint8
+	mem uint32
+}
+
+func (r *resourceConfig) FromBundle(ctx context.Context, b *bundle.Bundle) error {
+	// Set default values.
+	r.cpu = 2
+	r.mem = 2048
+
+	if b.Spec.Annotations == nil {
+		return nil
+	}
+
+	for annotKey, annotValue := range b.Spec.Annotations {
+		switch annotKey {
+		case cpuAnnotation:
+			cpu, err := strconv.ParseUint(annotValue, 10, 8)
+			if err != nil {
+				return fmt.Errorf("failed to parse %s=%s: %w", annotKey, annotValue, err)
+			}
+			r.cpu = uint8(cpu)
+			delete(b.Spec.Annotations, annotKey)
+		case memAnnotation:
+			mem, err := strconv.ParseUint(annotValue, 10, 32)
+			if err != nil {
+				return fmt.Errorf("failed to parse %s=%s: %w", annotKey, annotValue, err)
+			}
+			r.mem = uint32(mem)
+			delete(b.Spec.Annotations, annotKey)
+		}
+	}
+
+	if r.cpu == 0 || r.mem == 0 {
+		return fmt.Errorf("cpu and memory must be greater than 0")
+	}
+
+	return nil
+}
+
+func (r *resourceConfig) SetupVM(ctx context.Context, vmi vm.Instance) error {
+	if err := vmi.SetCPUAndMemory(ctx, r.cpu, r.mem); err != nil {
+		return fmt.Errorf("failed to apply VM resources configuration: %w", err)
+	}
+	return nil
+}

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -198,6 +198,17 @@ func (v *vmInstance) AddNIC(ctx context.Context, endpoint string, mac net.Hardwa
 	return nil
 }
 
+func (v *vmInstance) SetCPUAndMemory(ctx context.Context, cpu uint8, ram uint32) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if err := v.vmc.SetCPUAndMemory(cpu, ram); err != nil {
+		return fmt.Errorf("failed to set cpu and memory: %w", err)
+	}
+
+	return nil
+}
+
 func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -205,9 +216,6 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 		return errors.New("VM instance already started")
 	}
 
-	if err := v.vmc.SetCPUAndMemory(2, 2096); err != nil {
-		return fmt.Errorf("failed to set cpu and memory: %w", err)
-	}
 	if err := v.vmc.SetKernel(v.kernelPath, v.initrdPath, "console=hvc0"); err != nil {
 		return fmt.Errorf("failed to set kernel: %w", err)
 	}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -55,6 +55,7 @@ type MountConfig struct {
 type MountOpt func(*MountConfig)
 
 type Instance interface {
+	SetCPUAndMemory(ctx context.Context, cpu uint8, ram uint32) error
 	AddFS(ctx context.Context, tag, mountPath string, opts ...MountOpt) error
 	AddDisk(ctx context.Context, blockID, mountPath string, opts ...MountOpt) error
 	AddNIC(ctx context.Context, endpoint string, mac net.HardwareAddr, mode NetworkMode, features, flags uint32) error


### PR DESCRIPTION
Add support for two new OCI annotations:

- `io.containerd.nerdbox.resources.cpu`: numnber of vCPUs to allocate to the VM.
- `io.containerd.nerdbox.resources.memory`: amount of RAM to allocate to the VM, in MiB.