### PR TITLE
shim/task: relax VM network config validation

### DIFF
--- a/docs/vm-configuration.md
+++ b/docs/vm-configuration.md
@@ -41,9 +41,10 @@ that take the following fields:
 - `mac` (reqired): MAC address
 - `dhcp` (optional, defaults to false): tells the VM to retrieve the IPv4 address
   of this interface through DHCPv4.
-- `addr` (required): IP address with subnet mask (in CIDR notation). This field
-  can be specified either zero times (when `dhcp` is specified), or at most
-  twice (once per IP family).
+- `addr` (optional): IP address with subnet mask (in CIDR notation). This field
+  can be omitted (specified zero times) either when `dhcp` is enabled or when the
+  interface is intended to be L2-only (no IP assigned), and may be specified at
+  most twice otherwise (once per IP family).
 - `features` (optional, defaults to 0): Bitwise-OR separated list of virtio-net
   features. Supported features:
   - `VIRTIO_NET_F_CSUM`: Device handles packets with partial checksum offload
@@ -60,6 +61,10 @@ that take the following fields:
   will produce an error.
 
 Note that the first network specified will be used as the default gateway.
+
+If neither `addr` nor `dhcp` are specified, the network interface will have no IP
+address assigned and will be used exclusively to switch packets between the VM
+and the host.
 
 #### gvisor-tap-vsock
 

--- a/internal/shim/task/networking_unix.go
+++ b/internal/shim/task/networking_unix.go
@@ -154,8 +154,8 @@ func parseNetwork(annotation string) (network, error) {
 		}
 	}
 
-	if n.endpoint == "" || n.mode == "" || n.mac == nil || (!n.dhcp && !n.addr4.IsValid() && !n.addr6.IsValid()) {
-		return network{}, fmt.Errorf("either 'endpoint', 'mode', 'mac', 'dhcp' or 'addr' is missing")
+	if n.endpoint == "" || n.mode == "" || n.mac == nil {
+		return network{}, fmt.Errorf("missing required field(s): endpoint, mode, mac")
 	}
 
 	return n, nil

--- a/internal/vminit/vmnetworking/vmnetworking.go
+++ b/internal/vminit/vmnetworking/vmnetworking.go
@@ -45,8 +45,8 @@ type Network struct {
 }
 
 func (nw Network) Validate() error {
-	if nw.MAC == nil || (!nw.Addr4.IsValid() && !nw.Addr6.IsValid() && !nw.DHCP) {
-		return errors.New("must specify either addr or dhcp")
+	if nw.MAC == nil {
+		return errors.New("must specify MAC address")
 	}
 	if (nw.Addr4.IsValid() || nw.Addr6.IsValid()) && nw.DHCP {
 		return errors.New("cannot specify both addr and dhcp")


### PR DESCRIPTION
Allow VM network interfaces to be configured without an IP address or DHCP enabled. This validation rule was preventing the use of /31 networks.

Most of the time, the VM doesn't need to have an IP address assigned since its interface is added to the bridge network that serves the container. However, this means containers running within the 'host' network namespace won't have any connectivity. It's up to the higher-level runtime to decide whether this is an acceptable trade-off.