### PR TITLE
Update stream interface for vsock

### DIFF
--- a/integration/vm_test.go
+++ b/integration/vm_test.go
@@ -45,7 +45,7 @@ func TestSystemInfo(t *testing.T) {
 
 func TestStreamInitialization(t *testing.T) {
 	runWithVM(t, func(t *testing.T, i vm.Instance) {
-		sid1, conn, err := i.StartStream(t.Context())
+		conn, err := i.StartStream(t.Context(), "test-stream-1")
 		if err != nil {
 			if errors.Is(err, errdefs.ErrNotImplemented) {
 				t.Skip("streaming not implemented")
@@ -53,21 +53,13 @@ func TestStreamInitialization(t *testing.T) {
 			t.Fatal("failed to start stream client:", err)
 		}
 
-		if sid1 == 0 {
-			t.Fatal("expected non-zero stream id")
-		}
-
 		if err := conn.Close(); err != nil {
 			t.Fatal("failed to close stream connection:", err)
 		}
 
-		sid2, conn, err := i.StartStream(t.Context())
+		conn, err = i.StartStream(t.Context(), "test-stream-2")
 		if err != nil {
 			t.Fatal("failed to start stream client:", err)
-		}
-
-		if sid2 <= sid1 {
-			t.Fatalf("expected stream id %d, previous was %d", sid2, sid1)
 		}
 
 		if err := conn.Close(); err != nil {

--- a/internal/shim/sandbox/sandbox.go
+++ b/internal/shim/sandbox/sandbox.go
@@ -31,7 +31,7 @@ type Sandbox interface {
 	Start(context.Context, ...Opt) error
 	Stop(context.Context) error
 	Client() (*ttrpc.Client, error)
-	StartStream(ctx context.Context) (uint32, net.Conn, error)
+	StartStream(context.Context, string) (net.Conn, error)
 }
 
 type Filesystem struct {

--- a/internal/shim/sandbox/vm/vm.go
+++ b/internal/shim/sandbox/vm/vm.go
@@ -140,13 +140,13 @@ func (s *localsandbox) Client() (*ttrpc.Client, error) {
 	return s.instance.Client(), nil
 }
 
-func (s *localsandbox) StartStream(ctx context.Context) (uint32, net.Conn, error) {
+func (s *localsandbox) StartStream(ctx context.Context, streamID string) (net.Conn, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.instance == nil {
-		return 0, nil, errdefs.ErrFailedPrecondition
+		return nil, errdefs.ErrFailedPrecondition
 	}
 
-	return s.instance.StartStream(ctx)
+	return s.instance.StartStream(ctx, streamID)
 }

--- a/internal/shim/task/io.go
+++ b/internal/shim/task/io.go
@@ -18,6 +18,8 @@ package task
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -27,6 +29,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/v2/pkg/stdio"
 	"github.com/containerd/errdefs"
@@ -35,10 +38,18 @@ import (
 )
 
 type streamCreator interface {
-	StartStream(ctx context.Context) (uint32, net.Conn, error)
+	StartStream(ctx context.Context, streamID string) (net.Conn, error)
 }
 
-func (s *service) forwardIO(ctx context.Context, ss streamCreator, sio stdio.Stdio) (stdio.Stdio, func(ctx context.Context) error, error) {
+// generateStreamID creates a pseudo-random stream ID with the given prefix.
+// The format is "{prefix}-{nanosecond}-{random}" to minimize collisions.
+func generateStreamID(prefix string) string {
+	var b [4]byte
+	rand.Read(b[:])
+	return fmt.Sprintf("%s-%d-%s", prefix, time.Now().UnixNano(), base64.RawURLEncoding.EncodeToString(b[:]))
+}
+
+func (s *service) forwardIO(ctx context.Context, ss streamCreator, idPrefix string, sio stdio.Stdio) (stdio.Stdio, func(ctx context.Context) error, error) {
 	pio := sio
 	if pio.IsNull() {
 		return pio, nil, nil
@@ -56,7 +67,7 @@ func (s *service) forwardIO(ctx context.Context, ss streamCreator, sio stdio.Std
 		// Pass through
 		return pio, nil, nil
 	case "fifo":
-		pio, streams, err = createStreams(ctx, ss, pio)
+		pio, streams, err = createStreams(ctx, ss, idPrefix, pio)
 		if err != nil {
 			return stdio.Stdio{}, nil, err
 		}
@@ -75,7 +86,7 @@ func (s *service) forwardIO(ctx context.Context, ss streamCreator, sio stdio.Std
 		f.Close()
 		pio.Stdout = filePath
 		pio.Stderr = filePath
-		pio, streams, err = createStreams(ctx, ss, pio)
+		pio, streams, err = createStreams(ctx, ss, idPrefix, pio)
 		if err != nil {
 			return stdio.Stdio{}, nil, err
 		}
@@ -115,7 +126,7 @@ func (s *service) forwardIO(ctx context.Context, ss streamCreator, sio stdio.Std
 	}, nil
 }
 
-func createStreams(ctx context.Context, ss streamCreator, io stdio.Stdio) (_ stdio.Stdio, conns [3]io.ReadWriteCloser, err error) {
+func createStreams(ctx context.Context, ss streamCreator, idPrefix string, io stdio.Stdio) (_ stdio.Stdio, conns [3]io.ReadWriteCloser, err error) {
 	defer func() {
 		if err != nil {
 			for i, c := range conns {
@@ -126,21 +137,23 @@ func createStreams(ctx context.Context, ss streamCreator, io stdio.Stdio) (_ std
 		}
 	}()
 	if io.Stdin != "" {
-		sid, conn, err := ss.StartStream(ctx)
+		sid := generateStreamID(idPrefix + "-stdin")
+		conn, err := ss.StartStream(ctx, sid)
 		if err != nil {
-			return io, conns, fmt.Errorf("failed to start fifo stream: %w", err)
+			return io, conns, fmt.Errorf("failed to start stdin stream: %w", err)
 		}
-		io.Stdin = fmt.Sprintf("stream://%d", sid)
+		io.Stdin = fmt.Sprintf("stream://%s", sid)
 		conns[0] = conn
 	}
 
 	stdout := io.Stdout
 	if stdout != "" {
-		sid, conn, err := ss.StartStream(ctx)
+		sid := generateStreamID(idPrefix + "-stdout")
+		conn, err := ss.StartStream(ctx, sid)
 		if err != nil {
-			return io, conns, fmt.Errorf("failed to start fifo stream: %w", err)
+			return io, conns, fmt.Errorf("failed to start stdout stream: %w", err)
 		}
-		io.Stdout = fmt.Sprintf("stream://%d", sid)
+		io.Stdout = fmt.Sprintf("stream://%s", sid)
 		conns[1] = conn
 	}
 
@@ -149,11 +162,12 @@ func createStreams(ctx context.Context, ss streamCreator, io stdio.Stdio) (_ std
 			io.Stderr = io.Stdout
 			conns[2] = conns[1]
 		} else {
-			sid, conn, err := ss.StartStream(ctx)
+			sid := generateStreamID(idPrefix + "-stderr")
+			conn, err := ss.StartStream(ctx, sid)
 			if err != nil {
-				return io, conns, fmt.Errorf("failed to start fifo stream: %w", err)
+				return io, conns, fmt.Errorf("failed to start stderr stream: %w", err)
 			}
-			io.Stderr = fmt.Sprintf("stream://%d", sid)
+			io.Stderr = fmt.Sprintf("stream://%s", sid)
 			conns[2] = conn
 		}
 	}

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -284,7 +284,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		Terminal: r.Terminal,
 	}
 
-	cio, ioShutdown, err := s.forwardIO(ctx, s.sb, rio)
+	cio, ioShutdown, err := s.forwardIO(ctx, s.sb, r.ID, rio)
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
@@ -423,7 +423,7 @@ func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*pty
 		Terminal: r.Terminal,
 	}
 
-	cio, ioShutdown, err := s.forwardIO(ctx, s.sb, rio)
+	cio, ioShutdown, err := s.forwardIO(ctx, s.sb, r.ID+"-"+r.ExecID, rio)
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -28,7 +28,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"sync/atomic"
+
 	"syscall"
 	"time"
 
@@ -144,8 +144,6 @@ type vmInstance struct {
 	kernelPath string
 	initrdPath string
 	streamPath string
-
-	streamC uint32
 
 	lib     *libkrun
 	handler uintptr
@@ -355,45 +353,50 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 	return nil
 }
 
-func (v *vmInstance) StartStream(ctx context.Context) (uint32, net.Conn, error) {
-	var conn net.Conn
+func (v *vmInstance) StartStream(ctx context.Context, streamID string) (net.Conn, error) {
 	const timeIncrement = 10 * time.Millisecond
 	for d := timeIncrement; d < time.Second; d += timeIncrement {
-		sid := atomic.AddUint32(&v.streamC, 1)
-		if sid == 0 {
-			return 0, nil, fmt.Errorf("exhausted stream identifiers: %w", errdefs.ErrUnavailable)
-		}
 		select {
 		case <-ctx.Done():
-			return 0, nil, ctx.Err()
+			return nil, ctx.Err()
 		default:
 		}
 		if _, err := os.Stat(v.streamPath); err == nil {
-			conn, err = net.Dial("unix", v.streamPath)
+			conn, err := net.Dial("unix", v.streamPath)
 			if err != nil {
-				return 0, nil, fmt.Errorf("failed to connect to stream server: %w", err)
+				return nil, fmt.Errorf("failed to connect to stream server: %w", err)
 			}
-			var vs [4]byte
-			binary.BigEndian.PutUint32(vs[:], sid)
-			if _, err := conn.Write(vs[:]); err != nil {
+			// Write length-prefixed stream ID
+			idBytes := []byte(streamID)
+			if err := binary.Write(conn, binary.BigEndian, uint32(len(idBytes))); err != nil {
 				conn.Close()
-				return 0, nil, fmt.Errorf("failed to write stream id to stream server: %w", err)
+				return nil, fmt.Errorf("failed to write stream id length: %w", err)
 			}
-			// Wait for ack
-			var ack [4]byte
-			if _, err := io.ReadFull(conn, ack[:]); err != nil {
+			if _, err := conn.Write(idBytes); err != nil {
 				conn.Close()
-				return 0, nil, fmt.Errorf("failed to read ack from stream server: %w", err)
+				return nil, fmt.Errorf("failed to write stream id: %w", err)
 			}
-			if binary.BigEndian.Uint32(ack[:]) != sid {
+			// Wait for ack (length-prefixed string echoed back)
+			var ackLen uint32
+			if err := binary.Read(conn, binary.BigEndian, &ackLen); err != nil {
 				conn.Close()
-				return 0, nil, fmt.Errorf("stream server ack mismatch: got %d, expected %d", binary.BigEndian.Uint32(ack[:]), sid)
+				return nil, fmt.Errorf("failed to read ack length: %w", err)
+			}
+			ackBytes := make([]byte, ackLen)
+			if _, err := io.ReadFull(conn, ackBytes); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("failed to read ack: %w", err)
+			}
+			if ack := string(ackBytes); ack != streamID {
+				conn.Close()
+				return nil, fmt.Errorf("stream %q rejected by server: %s", streamID, ack)
 			}
 
-			return sid, conn, nil
+			return conn, nil
 		}
+		time.Sleep(d)
 	}
-	return 0, nil, fmt.Errorf("timeout waiting for stream server: %w", errdefs.ErrUnavailable)
+	return nil, fmt.Errorf("timeout waiting for stream server: %w", errdefs.ErrUnavailable)
 }
 
 func (v *vmInstance) Client() *ttrpc.Client {

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -63,13 +63,13 @@ type Instance interface {
 	Client() *ttrpc.Client
 	Shutdown(context.Context) error
 
-	// StartStream makes a connection to the VM for streaming, returning a 32-bit
-	// identifier for the stream that can be used to reference the stream inside
-	// the vm.
+	// StartStream makes a connection to the VM for streaming with the given
+	// stream ID. The stream ID is passed to the VM so it can be used to
+	// reference the stream inside the VM.
 	//
 	// TODO: Consider making this interface optional, a per RPC implementation
 	// is possible but likely less efficient.
-	StartStream(ctx context.Context) (uint32, net.Conn, error)
+	StartStream(ctx context.Context, streamID string) (net.Conn, error)
 }
 
 func WithReadOnly() MountOpt {

--- a/internal/vminit/process/utils.go
+++ b/internal/vminit/process/utils.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -226,13 +225,10 @@ func getStream(uri string, sm stream.Manager) (io.ReadWriteCloser, error) {
 	if !strings.HasPrefix(uri, "stream://") {
 		return nil, fmt.Errorf("not a stream: %s", errdefs.ErrInvalidArgument)
 	}
-	sid, err := strconv.ParseUint(uri[9:], 10, 32)
+	sid := uri[9:]
+	c, err := sm.Get(sid)
 	if err != nil {
-		return nil, fmt.Errorf("invalid stream id %q: %w", uri, err)
-	}
-	c, err := sm.Get(uint32(sid))
-	if err != nil {
-		return nil, fmt.Errorf("unable to get stream %d: %w", sid, errdefs.ErrNotFound)
+		return nil, fmt.Errorf("unable to get stream %q: %w", sid, errdefs.ErrNotFound)
 	}
 	return c, err
 }

--- a/internal/vminit/runc/platform.go
+++ b/internal/vminit/runc/platform.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -81,12 +80,7 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 	if stdin != "" {
 		var in io.ReadCloser
 		if s, ok := strings.CutPrefix(stdin, "stream://"); ok {
-			var sid uint64
-			sid, err = strconv.ParseUint(s, 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			in, err = p.streams.Get(uint32(sid))
+			in, err = p.streams.Get(s)
 			cstdin = in
 		} else {
 			in, err = fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
@@ -114,11 +108,7 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 
 	switch uri.Scheme {
 	case "stream":
-		sid, err := strconv.ParseUint(strings.TrimPrefix(stdout, "stream://"), 10, 32)
-		if err != nil {
-			return nil, err
-		}
-		out, err := p.streams.Get(uint32(sid))
+		out, err := p.streams.Get(strings.TrimPrefix(stdout, "stream://"))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/vminit/stream/stream.go
+++ b/internal/vminit/stream/stream.go
@@ -19,5 +19,5 @@ package stream
 import "io"
 
 type Manager interface {
-	Get(id uint32) (io.ReadWriteCloser, error)
+	Get(id string) (io.ReadWriteCloser, error)
 }

--- a/plugins/vminit/streaming/plugin.go
+++ b/plugins/vminit/streaming/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/shutdown"
 	cplugins "github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/mdlayher/vsock"
@@ -66,7 +67,7 @@ func init() {
 
 			s := &service{
 				l:       l,
-				streams: make(map[uint32]net.Conn),
+				streams: make(map[string]net.Conn),
 			}
 
 			ss.(shutdown.Service).RegisterCallback(s.Shutdown)
@@ -82,7 +83,7 @@ type service struct {
 	mu sync.Mutex
 	l  net.Listener
 
-	streams map[uint32]net.Conn
+	streams map[string]net.Conn
 }
 
 func (s *service) Shutdown(ctx context.Context) error {
@@ -107,61 +108,77 @@ func (s *service) Shutdown(ctx context.Context) error {
 		return errors.Join(errs...)
 	}
 	return nil
-
 }
+
 func (s *service) Run() {
 	for {
 		conn, err := s.l.Accept()
 		if err != nil {
 			return // Listener closed
 		}
-		var b [4]byte
-		if _, err := conn.Read(b[:]); err != nil {
+
+		// Read length-prefixed stream ID
+		var idLen uint32
+		if err := binary.Read(conn, binary.BigEndian, &idLen); err != nil {
+			log.L.WithError(err).Debug("failed to read stream ID length")
 			conn.Close()
-			continue // Error reading, close connection
+			continue
 		}
+		idBytes := make([]byte, idLen)
+		if _, err := io.ReadFull(conn, idBytes); err != nil {
+			log.L.WithError(err).Debug("failed to read stream ID")
+			conn.Close()
+			continue
+		}
+		streamID := string(idBytes)
 
 		s.mu.Lock()
-		sid := binary.BigEndian.Uint32(b[:])
-		if _, ok := s.streams[sid]; ok {
+		if _, ok := s.streams[streamID]; ok {
 			s.mu.Unlock()
+			log.L.WithField("stream", streamID).Debug("duplicate stream ID, rejecting")
+			// Send back an error message so the client gets a meaningful rejection
+			errMsg := fmt.Sprintf("stream %q already exists", streamID)
+			writeString(conn, errMsg)
 			conn.Close()
-			continue // Error reading, close connection
+			continue
 		}
-		s.streams[sid] = streamConn{
-			Conn: conn,
-			sid:  sid,
-			s:    s,
-		}
+		s.streams[streamID] = conn
 		s.mu.Unlock()
-		conn.Write(b[:])
+
+		// Ack: echo back the stream ID
+		if err := writeString(conn, streamID); err != nil {
+			s.removeStream(streamID)
+			conn.Close()
+			continue
+		}
 	}
 }
 
-func (s *service) Get(id uint32) (io.ReadWriteCloser, error) {
+func (s *service) removeStream(streamID string) {
+	s.mu.Lock()
+	delete(s.streams, streamID)
+	s.mu.Unlock()
+}
+
+// writeString writes a length-prefixed string to the connection.
+func writeString(conn net.Conn, s string) error {
+	b := []byte(s)
+	if err := binary.Write(conn, binary.BigEndian, uint32(len(b))); err != nil {
+		return err
+	}
+	_, err := conn.Write(b)
+	return err
+}
+
+// Get returns the raw connection for the given stream ID, removing it from
+// the map. This implements stream.Manager for the task service IO forwarding.
+func (s *service) Get(id string) (io.ReadWriteCloser, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	c, ok := s.streams[id]
+	conn, ok := s.streams[id]
 	if !ok {
-		return nil, fmt.Errorf("stream %d not found: %w", id, errdefs.ErrNotFound)
+		return nil, fmt.Errorf("stream %q not found: %w", id, errdefs.ErrNotFound)
 	}
-	return c, nil
-}
-
-type streamConn struct {
-	net.Conn
-	sid uint32
-	s   *service
-}
-
-func (sc streamConn) Close() error {
-	sc.s.mu.Lock()
-	defer sc.s.mu.Unlock()
-	delete(sc.s.streams, sc.sid)
-
-	if err := sc.Conn.Close(); err != nil {
-		return fmt.Errorf("failed to close connection: %w", err)
-	}
-
-	return nil
+	delete(s.streams, id)
+	return conn, nil
 }


### PR DESCRIPTION
Split out from #99 

Updates the stream creator interface to create streams with a given identifier rather than returning an ID from the vm side. This removes an unnecessary ID mapping layer as the vm already needs to hold a map and the host already needs to support references streams by unique identifiers.