### PR TITLE
Allow GOPROXY env setting passthrough

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,10 +130,11 @@ ARG GO_LDFLAGS
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
+ARG GOPROXY
 
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=shim-build-$TARGETPLATFORM \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/containerd-shim-nerdbox-v1 ${GO_LDFLAGS} -tags 'no_grpc' ./cmd/containerd-shim-nerdbox-v1
+    GOOS=${TARGETOS} GOPROXY=${GOPROXY} GOARCH=${TARGETARCH} go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/containerd-shim-nerdbox-v1 ${GO_LDFLAGS} -tags 'no_grpc' ./cmd/containerd-shim-nerdbox-v1
 
 FROM base AS vminit-build
 
@@ -144,10 +145,11 @@ ARG GO_GCFLAGS
 ARG GO_BUILD_FLAGS
 ARG TARGETPLATFORM
 ARG TARGETARCH
+ARG GOPROXY
 
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=vminit-build-$TARGETPLATFORM \
-    GOARCH=${TARGETARCH} go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/vminitd -ldflags '-extldflags \"-static\" -s -w' -tags 'osusergo netgo static_build no_grpc'  ./cmd/vminitd
+    GOARCH=${TARGETARCH} GOPROXY=${GOPROXY} go build ${GO_DEBUG_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o /build/vminitd -ldflags '-extldflags \"-static\" -s -w' -tags 'osusergo netgo static_build no_grpc'  ./cmd/vminitd
 
 # TODO: Use nix instructions to build crun statically
 #FROM base AS crun-src

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -30,6 +30,10 @@ variable "GOLANGCI_LINT_MULTIPLATFORM" {
   default = ""
 }
 
+variable "GOPROXY" {
+  default = ""
+}
+
 target "_common" {
   args = {
     KERNEL_VERSION = KERNEL_VERSION
@@ -39,6 +43,7 @@ target "_common" {
     GO_GCFLAGS = GO_GCFLAGS
     GO_DEBUG_GCFLAGS = GO_DEBUG_GCFLAGS
     GO_LDFLAGS = GO_LDFLAGS
+    GOPROXY = GOPROXY
   }
 }
 


### PR DESCRIPTION
This allows for nerdbox to be built in corporate environments where the Go language proxies are inaccessible. This can be enabled by supporting the GOPROXY=direct setting; this PR plumbs through the passing of the GOPROXY variable into the build.