### PR TITLE
shim/manager: Ensure parent socket directory exists

### DIFF
--- a/internal/shim/manager/manager.go
+++ b/internal/shim/manager/manager.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -136,6 +137,15 @@ func newShimSocket(ctx context.Context, root, path, id string, debug bool) (*shi
 	if err != nil {
 		return nil, err
 	}
+
+	// Workaround: shim.NewSocket expects the parent directory to exist.
+	// Ensure the socket directory exists before creating the socket.
+	// TODO: Remove after https://github.com/containerd/containerd/pull/12960
+	addrParentDir := filepath.Base(strings.TrimPrefix("unix://", address))
+	if err := os.MkdirAll(addrParentDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create socket directory: %w", err)
+	}
+
 	socket, err := shim.NewSocket(address)
 	if err != nil {
 		// the only time where this would happen is if there is a bug and the socket


### PR DESCRIPTION
- workarounds: https://github.com/containerd/containerd/pull/12960

Workaround for a bug in containerd's shim.NewSocket that fails when the parent directory for the socket doesn't exist.

Ensure the socket root directory is created with appropriate permissions (has executable bit for the owner) before attempting to create the Unix socket.