### PR TITLE
Fix  `apparmor_restrict_unprivileged_userns=1` with relaxed apparmor profile

### DIFF
--- a/internal/shim/manager/mount_linux.go
+++ b/internal/shim/manager/mount_linux.go
@@ -22,8 +22,6 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
-
-	"github.com/containerd/log"
 )
 
 // cloneMntNs configures the child command to start in a new user + mount
@@ -55,12 +53,16 @@ import (
 // If namespace creation is not possible (e.g. AppArmor restricts
 // unprivileged user namespaces), the function logs a warning and the shim
 // will run without mount isolation.
-func cloneMntNs(ctx context.Context, cmd *exec.Cmd) {
+func cloneMntNs(_ context.Context, cmd *exec.Cmd) {
 	if restricted, err := apparmorRestrictsUserns(); err != nil {
-		log.G(ctx).WithError(err).Warn("failed to check apparmor userns restriction, skipping mount namespace isolation")
+		// Failed to check apparmor userns restriction, skipping mount namespace isolation")
+		// We can't log anything here as it will break the TTRPC protocol!
+		// TODO(vvoland): Find a better way to surface this to the user.
 		return
 	} else if restricted {
-		log.G(ctx).Warn("apparmor_restrict_unprivileged_userns=1 prevents user namespace creation; shim will run without mount namespace isolation")
+		// apparmor_restrict_unprivileged_userns=1 prevents user namespace creation; shim will run without mount namespace isolation
+		// We can't log anything here as it will break the TTRPC protocol!
+		// TODO(vvoland): Find a better way to surface this to the user.
 		return
 	}
 


### PR DESCRIPTION
When AppArmor restricts user namespace creation or checking the restriction fails, the logging calls in cloneMntNs break the TTRPC protocol by writing to stderr during shim initialization.

This causes the shim to fail:

```
ERROR: failed to create sandbox: create sandbox: create sandbox: run sandbox: start container: container start: Error response from daemon: creating containerd task for container 4677c157669e: failed to start shim: start failed: failed to create TTRPC connection: unsupported protocol: time="2026-04-03T10:29:20+02:00" level=warning msg="apparmor_restrict_unprivileged_userns=1 prevents user namespace creation; shim will run without mount namespace isolation" runtime=io.containerd.nerdbox.v1
{"version":3,"address":"unix
```