### PR TITLE
shim/manager: Detect custom AppArmor profile to allow userns creation

### DIFF
--- a/internal/shim/manager/mount_linux.go
+++ b/internal/shim/manager/mount_linux.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -87,5 +88,25 @@ func apparmorRestrictsUserns() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return strings.TrimSpace(string(data)) == "1", nil
+	if strings.TrimSpace(string(data)) == "1" {
+		if runningUnderCustomProfile() {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// runningUnderCustomProfile checks /proc/self/attr/current for an AppArmor
+// profile name that contains the current binary name. If present, we are
+// likely running under a custom profile that relaxes the userns restriction
+// for this binary, so we should proceed with namespace creation.
+func runningUnderCustomProfile() bool {
+	data, err := os.ReadFile("/proc/self/attr/current")
+	if err != nil {
+		return false
+	}
+	profile := strings.TrimSpace(string(data))
+	return strings.Contains(profile, filepath.Base(os.Args[0]))
 }


### PR DESCRIPTION
When kernel.apparmor_restrict_unprivileged_userns=1, check /proc/self/attr/current for a profile name containing the binary name.

If found, we are likely running under a custom AppArmor profile that relaxes the userns restriction, so proceed with namespace creation instead of skipping it.