### PR TITLE
Switch connect direction to have vminitd dial back to shim

### DIFF
--- a/cmd/vminitd/listener.go
+++ b/cmd/vminitd/listener.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/mdlayher/vsock"
+)
+
+// dialBackListener is a net.Listener that dials a vsock connection to the
+// host on the first Accept call, then blocks on subsequent calls until
+// Close is called. This allows a ttrpc.Server to serve a single connection
+// initiated by dialing the host rather than listening for connections.
+type dialBackListener struct {
+	cid  uint32
+	port uint32
+
+	once    sync.Once
+	done    chan struct{}
+	dialErr error
+}
+
+func newDialBackListener(cid, port uint32) *dialBackListener {
+	return &dialBackListener{
+		cid:  cid,
+		port: port,
+		done: make(chan struct{}),
+	}
+}
+
+func (l *dialBackListener) Accept() (net.Conn, error) {
+	var (
+		conn net.Conn
+		dial bool
+	)
+	l.once.Do(func() {
+		dial = true
+		conn, l.dialErr = vsock.Dial(l.cid, l.port, nil)
+		if l.dialErr != nil {
+			close(l.done)
+		}
+	})
+	if dial {
+		if l.dialErr != nil {
+			return nil, fmt.Errorf("failed to dial host vsock %d:%d: %w", l.cid, l.port, l.dialErr)
+		}
+		return conn, nil
+	}
+	// Block until the listener is closed.
+	<-l.done
+	return nil, net.ErrClosed
+}
+
+func (l *dialBackListener) Close() error {
+	select {
+	case <-l.done:
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+func (l *dialBackListener) Addr() net.Addr {
+	return &vsock.Addr{
+		ContextID: l.cid,
+		Port:      l.port,
+	}
+}

--- a/cmd/vminitd/main.go
+++ b/cmd/vminitd/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/containerd/ttrpc"
-	"github.com/mdlayher/vsock"
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/nerdbox/internal/systools"
@@ -286,10 +285,10 @@ func New(ctx context.Context, config ServiceConfig) (Runnable, error) {
 		// TODO: service config?
 	)
 
-	l, err := vsock.ListenContextID(uint32(config.VSockContextID), uint32(config.RPCPort), &vsock.Config{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on vsock port %d with context id %d: %w", config.RPCPort, config.VSockContextID, err)
-	}
+	// Dial back to the host via vsock instead of listening. The host shim
+	// is listening for this connection. CID 2 is the well-known host CID.
+	const hostCID = 2
+	l := newDialBackListener(uint32(hostCID), uint32(config.RPCPort))
 	config.Shutdown.RegisterCallback(func(ctx context.Context) error {
 		return l.Close()
 	})

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -221,12 +221,17 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	opts = append(opts, resCfg.SandboxOpts()...)
 	opts = append(opts, dumpInfoCfg.SandboxOpts()...)
 
+	premountTime := time.Since(presetup)
+
 	prestart := time.Now()
 	if err := s.sb.Start(ctx, opts...); err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
 	bootTime := time.Since(prestart)
-	log.G(ctx).WithField("bootTime", bootTime).Debug("VM started")
+	log.G(ctx).WithFields(log.Fields{
+		"bootTime":     bootTime,
+		"premountTime": premountTime,
+	}).Info("VM started")
 
 	vmc, err := s.sb.Client()
 	if err != nil {

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -34,7 +34,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 
-	"github.com/containerd/nerdbox/internal/ttrpcutil"
 	"github.com/containerd/nerdbox/internal/vm"
 )
 
@@ -214,6 +213,7 @@ func (v *vmInstance) SetCPUAndMemory(ctx context.Context, cpu uint8, ram uint32)
 }
 
 func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error) {
+	startedAt := time.Now()
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if v.client != nil {
@@ -258,7 +258,6 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 		go io.Copy(consoleW, lr)
 	}
 
-	// Consider not using unix sockets here and directly connecting via vsock
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get cwd: %w", err)
@@ -269,15 +268,24 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 	if err != nil {
 		return fmt.Errorf("failed to get relative socket path: %w", err)
 	}
-	// When the socket path exceeds max length, it appears as if the VM didn't
-	// start properly. There's no easy way to figure this out as the only log
-	// is: "Timeout while waiting for VM to start". Thus, return an error
-	// preventively here.
 	if (runtime.GOOS == "darwin" && len(socketPath) >= 104) || len(socketPath) >= 108 {
 		return fmt.Errorf("socket path is too long: %s", socketPath)
 	}
 
-	if err := v.vmc.AddVSockPort(1025, socketPath); err != nil {
+	// Listen on the unix socket so vminitd can connect back to us.
+	// AddVSockPortConnect (listen=false) tells libkrun to connect to this
+	// socket when the guest dials the vsock port, bridging the connection.
+	// Remove any stale socket left behind by a previous crash.
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove stale socket: %w", err)
+	}
+	rpcListener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to listen on socket: %w", err)
+	}
+	defer rpcListener.Close()
+
+	if err := v.vmc.AddVSockPortConnect(1025, socketPath); err != nil {
 		return fmt.Errorf("failed to add vsock port: %w", err)
 	}
 
@@ -288,6 +296,8 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 	if err := v.vmc.AddVSockPort(1026, v.streamPath); err != nil {
 		return fmt.Errorf("failed to add vsock port: %w", err)
 	}
+
+	preVMStart := time.Now()
 
 	// Start it
 	errC := make(chan error)
@@ -312,55 +322,45 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 		},
 	}
 
+	// Accept a single connection from vminitd connecting back via vsock.
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	acceptC := make(chan acceptResult, 1)
+	go func() {
+		conn, err := rpcListener.Accept()
+		acceptC <- acceptResult{conn, err}
+	}()
+
 	var conn net.Conn
-	// Initial TTRPC ping deadline. On Windows, the vsock listen-mode proxy
-	// has more overhead (host→Unix socket→vsock→guest→vsock→Unix socket→host)
-	// so we start with a longer deadline.
-	d := 2 * time.Millisecond
-	if runtime.GOOS == "windows" {
-		d = 500 * time.Millisecond
+	select {
+	case err := <-errC:
+		if err != nil {
+			return fmt.Errorf("failure running vm: %w", err)
+		}
+		return fmt.Errorf("VM exited before connecting")
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(vmStartTimeout):
+		log.G(ctx).WithField("timeout", vmStartTimeout).Warn("Timeout while waiting for VM to connect")
+		return fmt.Errorf("VM did not connect within %s", vmStartTimeout)
+	case result := <-acceptC:
+		if result.err != nil {
+			return fmt.Errorf("failed to accept connection from VM: %w", result.err)
+		}
+		conn = result.conn
 	}
-	startedAt := time.Now()
-	for {
-		select {
-		case err := <-errC:
-			if err != nil {
-				return fmt.Errorf("failure running vm: %w", err)
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Millisecond):
-		}
-		if time.Since(startedAt) > vmStartTimeout {
-			log.G(ctx).WithField("timeout", vmStartTimeout).Warn("Timeout while waiting for VM to start")
-			return fmt.Errorf("VM did not start within %s", vmStartTimeout)
-		}
-		if _, err := os.Stat(socketPath); err == nil {
-			conn, err = net.Dial("unix", socketPath)
-			if err != nil {
-				log.G(ctx).WithError(err).Debugf("VM socket not ready yet. Retrying in %s...", d)
-				continue
-			}
-			conn.SetReadDeadline(time.Now().Add(d))
-			if err := ttrpcutil.PingTTRPC(conn); err != nil {
-				conn.Close()
-				d = d + time.Millisecond
-				continue
-			}
 
-			conn.SetReadDeadline(time.Time{}) // Clear the deadline
-			// Ensure connection alive after deadline is cleared
-			if err := ttrpcutil.PingTTRPC(conn); err != nil {
-				conn.Close()
-				continue
-			}
+	log.G(ctx).WithFields(log.Fields{
+		"t_config": preVMStart.Sub(startedAt),
+		"t_boot":   time.Since(preVMStart),
+		"t_total":  time.Since(startedAt),
+	}).Info("VM connection established")
 
-			v.shutdownCallbacks = append(v.shutdownCallbacks, func(context.Context) error {
-				return conn.Close()
-			})
-			break
-		}
-	}
+	v.shutdownCallbacks = append(v.shutdownCallbacks, func(context.Context) error {
+		return conn.Close()
+	})
 
 	v.client = ttrpc.NewClient(conn)
 

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -132,6 +132,20 @@ func (vmc *vmcontext) AddVSockPort(port uint32, path string) error {
 	return nil
 }
 
+// AddVSockPortConnect maps a vsock port to a host unix socket in connect mode.
+// When the guest dials this vsock port, libkrun connects to the unix socket
+// at path, which must already be listening.
+func (vmc *vmcontext) AddVSockPortConnect(port uint32, path string) error {
+	if vmc.lib.AddVsockPort == nil {
+		return fmt.Errorf("libkrun not loaded")
+	}
+	ret := vmc.lib.AddVsockPort(vmc.ctxID, port, path, false)
+	if ret != 0 {
+		return fmt.Errorf("krun_add_vsock_port failed: %d", ret)
+	}
+	return nil
+}
+
 func (vmc *vmcontext) AddVirtiofs(tag, path string) error {
 	if vmc.lib.AddVirtiofs == nil {
 		return fmt.Errorf("libkrun not loaded")


### PR DESCRIPTION
The vminitd process dialing back to the shim avoids the polling from the shim side and allows the shim to immediately stop listening after the connection is made. Only a single ttrpc+vsock connection is needed and should be allowed, disallowing any other process inside the vm from being able to connect.