### PR TITLE
task shim: raise SIGSTOP when NERDBOX_SIGSTOP is set

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -47,6 +47,7 @@ import (
 	"github.com/containerd/nerdbox/internal/nwcfg"
 	"github.com/containerd/nerdbox/internal/shim/sandbox"
 	"github.com/containerd/nerdbox/internal/shim/task/bundle"
+	"github.com/containerd/nerdbox/internal/sigstop"
 )
 
 var (
@@ -105,6 +106,10 @@ type service struct {
 }
 
 func (s *service) RegisterTTRPC(server *ttrpc.Server) error {
+	if v := os.Getenv("NERDBOX_SIGSTOP"); v != "" {
+		// Raise a SIGSTOP to pause the shim until a debugger is attached.
+		sigstop.Raise()
+	}
 	taskAPI.RegisterTTRPCTaskService(server, s)
 	return nil
 }

--- a/internal/sigstop/sigstop_unix.go
+++ b/internal/sigstop/sigstop_unix.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sigstop
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/containerd/log"
+)
+
+func Raise() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR2)
+	defer signal.Stop(sigCh)
+
+	log.G(context.Background()).Debug("Waiting for SIGUSR2")
+	if err := syscall.Kill(os.Getpid(), syscall.SIGSTOP); err != nil {
+		panic(err)
+	}
+
+	<-sigCh
+	log.G(context.Background()).Debug("SIGUSR2 received. Resuming process.")
+}

--- a/internal/sigstop/sigstop_windows.go
+++ b/internal/sigstop/sigstop_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sigstop
+
+func Raise() {}


### PR DESCRIPTION
When this env var is set, the shim SIGSTOP itself to wait until a debugger is attached. When a debugger attaches, it sends SIGCONT to resume the process. Then, it waits for SIGUSR2 to give enough time to the debugger to set breakpoints before the ttrpc server starts.

Here's how I'm using it:

    # Start containerd with NERDBOX_SIGSTOP set in term1, and run a contaienr
    term2$ dlv $(ps aux | grep '[c]ontainerd-shim-nerdbox-v1' | awk '{print $2}') ./bin/containerd-shim-nerdbox-v1 --listen=127.0.0.1:2346 --headless
    term3$ pkill -SIGUSR2 containerd-shim-nerdbox-v1