### PR TITLE
Fix event forwarding from vminitd

### DIFF
--- a/internal/vminit/process/exec.go
+++ b/internal/vminit/process/exec.go
@@ -242,7 +242,7 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 	}
 	pid, err := pidFile.Read()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve OCI runtime exec pi: %wd", err)
+		return fmt.Errorf("failed to retrieve OCI runtime exec pid: %w", err)
 	}
 	e.pid.pid = pid
 	return nil

--- a/internal/vminit/process/io.go
+++ b/internal/vminit/process/io.go
@@ -434,6 +434,13 @@ func (b *binaryIO) cancel() error {
 
 	select {
 	case err := <-done:
+		// If the process exited due to the SIGTERM we just sent,
+		// that is expected and should not be treated as an error.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signal() == syscall.SIGTERM {
+				return nil
+			}
+		}
 		return err
 	case <-time.After(binaryIOProcTermTimeout):
 		log.L.Warn("failed to wait for shim logger process to exit, killing")

--- a/internal/vminit/process/io_util.go
+++ b/internal/vminit/process/io_util.go
@@ -45,7 +45,7 @@ func NewBinaryCmd(binaryURI *url.URL, id, ns string) *exec.Cmd {
 }
 
 // CloseFiles closes any files passed in.
-// It it used for cleanup in the event of unexpected errors.
+// It is used for cleanup in the event of unexpected errors.
 func CloseFiles(files ...*os.File) {
 	for _, file := range files {
 		file.Close()

--- a/internal/vminit/task/service.go
+++ b/internal/vminit/task/service.go
@@ -95,9 +95,22 @@ func NewTaskService(ctx context.Context, bundle string, publisher events.Publish
 	if err := s.initPlatform(); err != nil {
 		return nil, fmt.Errorf("failed to initialized platform behavior: %w", err)
 	}
-	go s.forward(ctx, publisher)
-	sd.RegisterCallback(func(context.Context) error {
+	forwardDone := make(chan struct{})
+	go func() {
+		defer close(forwardDone)
+		s.forward(ctx, publisher)
+	}()
+	sd.RegisterCallback(func(shutdownCtx context.Context) error {
+		// Close the events channel and wait for forward() to drain pending
+		// events before letting shutdown complete. Without this wait, the VM
+		// can power off before in-flight events are published to the host.
+		// Bound the wait by the shutdown context so a blocked publisher
+		// can't stall shutdown past the shutdown service's timeout.
 		close(s.events)
+		select {
+		case <-forwardDone:
+		case <-shutdownCtx.Done():
+		}
 		return nil
 	})
 


### PR DESCRIPTION
This change synchronizes some changes to the shim from containerd including an events issue that showed up during shim conformance testing (https://github.com/dmcgowan/shimtest/actions/runs/24819836245/job/72641937503)