### PR TITLE
Fix stream deadlocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/otelttrpc v0.1.0
 	github.com/containerd/plugin v1.1.0
-	github.com/containerd/ttrpc v1.2.8
+	github.com/containerd/ttrpc v1.2.9-0.20260501231634-6c2eed2b612e
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/ebitengine/purego v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/containerd/platforms v1.0.0-rc.4 h1:M42JrUT4zfZTqtkUwkr0GzmUWbfyO5VO0
 github.com/containerd/platforms v1.0.0-rc.4/go.mod h1:lKlMXyLybmBedS/JJm11uDofzI8L2v0J2ZbYvNsbq1A=
 github.com/containerd/plugin v1.1.0 h1:O+7lczNJVMy8rz0YNx3xGB8tTf5qY4i5abF041Ew19U=
 github.com/containerd/plugin v1.1.0/go.mod h1:qBTum+A8lJ6lO44A19Eo7y1OlcLj4OWFH1DA/vnHmcc=
-github.com/containerd/ttrpc v1.2.8 h1:xbVu6D4qF2jihdh9rDVOKqUMiFBQk6YctTdo1zk087Y=
-github.com/containerd/ttrpc v1.2.8/go.mod h1:wyZW2K79t4Hfcxl+GUvkZqRBzJlqFFvgEeeWXa42tyE=
+github.com/containerd/ttrpc v1.2.9-0.20260501231634-6c2eed2b612e h1:uMP9FpdM40x+cvSyg6PiiINN9/b2908f8CsF/fZ438g=
+github.com/containerd/ttrpc v1.2.9-0.20260501231634-6c2eed2b612e/go.mod h1:IvZPGIALrdh9ZNv7AvRrKHCfwVPPCueLO2yuwj3KIqE=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=

--- a/plugins/shim/streaming/plugin.go
+++ b/plugins/shim/streaming/plugin.go
@@ -19,6 +19,7 @@ package streaming
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -97,48 +98,56 @@ func (s *service) Stream(ctx context.Context, srv streamapi.TTRPCStreaming_Strea
 		return err
 	}
 
-	// Start bidirectional bridge between TTRPC and VM.
-	// Messages are forwarded as length-prefixed proto frames.
-	done := make(chan error, 2)
+	// Bridge messages in both directions as length-prefixed proto frames.
 
-	// TTRPC -> VM: receive typeurl.Any from containerd, frame and write to VM
+	// Client -> server: forward incoming messages to the VM.
 	go func() {
 		err := bridgeTTRPCToVM(srv, vmConn)
-		// Send a zero-length frame as an application-level EOF marker
-		// so the VM sees EOF on its reads. We avoid CloseWrite()
-		// because the vsock proxy turns transport-level shutdown into
-		// a bidirectional SHUTDOWN, which kills the reverse direction
-		// (VM -> TTRPC) and can cause the peer to lose in-flight data.
-		if eofErr := binary.Write(vmConn, binary.BigEndian, uint32(0)); eofErr != nil && err == nil {
-			err = fmt.Errorf("failed to write EOF marker to vm: %w", eofErr)
+		// Signal end-of-stream to the VM with a zero-length frame.
+		// We avoid CloseWrite() because the vsock proxy turns a
+		// transport-level shutdown into a bidirectional SHUTDOWN,
+		// which would kill the reverse direction and can cause the
+		// peer to lose in-flight data.
+		//
+		// Log the EOF marker failure independently: when the bridge
+		// returns io.EOF (client CloseSend) the dropped marker would
+		// otherwise be lost both by the err==nil check and the
+		// io.EOF filter on the bridge log below, leaving the VM
+		// hanging while waiting for the marker.
+		if eofErr := binary.Write(vmConn, binary.BigEndian, uint32(0)); eofErr != nil {
+			log.G(ctx).WithError(eofErr).WithField("stream", i.ID).Debug("failed to write EOF marker to vm")
 		}
-		done <- err
+		if err != nil && !errors.Is(err, io.EOF) {
+			log.G(ctx).WithError(err).WithField("stream", i.ID).Debug("client->server bridge ended")
+		}
 	}()
 
-	// VM -> TTRPC: read framed messages from VM, send to containerd
+	// Server -> client: forward VM messages back to the caller.
+	v2t := make(chan error, 1)
 	go func() {
-		done <- bridgeVMToTTRPC(vmConn, srv)
+		v2t <- bridgeVMToTTRPC(vmConn, srv)
 	}()
 
-	// Wait for both bridge directions to finish or context cancellation.
-	// We must not return early after just one direction finishes, because:
-	// 1. Returning closes the TTRPC server stream which can race with
-	//    other in-flight RPCs (e.g. Transfer) on the same connection.
-	// 2. Closing vmConn eagerly can truncate in-flight data that the
-	//    VM hasn't read yet.
-	// Instead, wait for both to finish naturally. For unidirectional
-	// streams, one direction will block until context cancellation
-	// (shim shutdown), which is correct — the stream stays alive as
-	// long as the connection does.
-	for n := 0; n < 2; n++ {
-		select {
-		case err := <-done:
-			if err != nil {
-				log.G(ctx).WithError(err).WithField("stream", i.ID).Debug("stream bridge direction ended")
-			}
-		case <-ctx.Done():
-			return nil
+	// The protocol contract is that the server initiates the close:
+	// once it has finished its work it writes a zero-length frame,
+	// which bridgeVMToTTRPC observes and returns nil for. Returning
+	// before that signal would race the deferred vmConn.Close()
+	// against the server's in-flight reads/writes and could silently
+	// drop data still buffered in the kernel.
+	//
+	// We deliberately do not also wait on the client->server
+	// direction: it can stay blocked in srv.Recv() if the client only
+	// issues CloseSend after observing the server's EOF, which itself
+	// requires this handler to return so ttrpc closes the server
+	// stream. Waiting would deadlock. Instead the goroutine exits on
+	// its own when ttrpc cancels the stream context on handler
+	// return (or when vmConn.Close unblocks an in-flight write).
+	select {
+	case err := <-v2t:
+		if err != nil && !errors.Is(err, io.EOF) {
+			log.G(ctx).WithError(err).WithField("stream", i.ID).Debug("server->client bridge ended")
 		}
+	case <-ctx.Done():
 	}
 
 	return nil

--- a/plugins/shim/streaming/plugin_test.go
+++ b/plugins/shim/streaming/plugin_test.go
@@ -1,0 +1,313 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package streaming
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	streamapi "github.com/containerd/containerd/api/services/streaming/v1"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/containerd/nerdbox/internal/shim/sandbox"
+)
+
+// fakeStreamServer implements streamapi.TTRPCStreaming_StreamServer in
+// memory so the service can be invoked without spinning up a ttrpc
+// server. The test feeds inbound messages via recvCh and reads outbound
+// ones via sendCh.
+type fakeStreamServer struct {
+	ctx    context.Context
+	recvCh chan *anypb.Any
+	sendCh chan *anypb.Any
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func newFakeStreamServer(ctx context.Context) *fakeStreamServer {
+	return &fakeStreamServer{
+		ctx:    ctx,
+		recvCh: make(chan *anypb.Any, 16),
+		sendCh: make(chan *anypb.Any, 16),
+	}
+}
+
+// closeRecv signals end-of-stream to the handler's Recv loop, mirroring
+// a client that has called CloseSend.
+func (f *fakeStreamServer) closeRecv() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return
+	}
+	f.closed = true
+	close(f.recvCh)
+}
+
+func (f *fakeStreamServer) Send(m *anypb.Any) error {
+	select {
+	case f.sendCh <- m:
+		return nil
+	case <-f.ctx.Done():
+		return f.ctx.Err()
+	}
+}
+
+func (f *fakeStreamServer) Recv() (*anypb.Any, error) {
+	select {
+	case a, ok := <-f.recvCh:
+		if !ok {
+			return nil, io.EOF
+		}
+		return a, nil
+	case <-f.ctx.Done():
+		return nil, f.ctx.Err()
+	}
+}
+
+func (f *fakeStreamServer) SendMsg(m interface{}) error {
+	return f.Send(m.(*anypb.Any))
+}
+
+func (f *fakeStreamServer) RecvMsg(m interface{}) error {
+	a, err := f.Recv()
+	if err != nil {
+		return err
+	}
+	dst, ok := m.(proto.Message)
+	if !ok {
+		return io.ErrUnexpectedEOF
+	}
+	proto.Reset(dst)
+	proto.Merge(dst, a)
+	return nil
+}
+
+// fakeSandbox is a minimal sandbox.Sandbox that hands out a pre-supplied
+// net.Conn from StartStream. The other methods are not exercised by the
+// Stream handler.
+type fakeSandbox struct {
+	conn net.Conn
+}
+
+func (s *fakeSandbox) Start(context.Context, ...sandbox.Opt) error { return errdefs.ErrNotImplemented }
+func (s *fakeSandbox) Stop(context.Context) error                  { return errdefs.ErrNotImplemented }
+func (s *fakeSandbox) Client() (*ttrpc.Client, error)              { return nil, errdefs.ErrNotImplemented }
+func (s *fakeSandbox) StartStream(context.Context, string) (net.Conn, error) {
+	return s.conn, nil
+}
+
+// streamInitAny marshals StreamInit{ID: id} as an *anypb.Any so it can
+// be fed to the handler through the fake server's Recv channel.
+func streamInitAny(t *testing.T, id string) *anypb.Any {
+	t.Helper()
+	a, err := typeurl.MarshalAnyToProto(&streamapi.StreamInit{ID: id})
+	if err != nil {
+		t.Fatalf("marshal StreamInit: %v", err)
+	}
+	return a
+}
+
+// startStream wires up a service+fake harness, kicks off the Stream
+// handler in a goroutine, drains the post-init ack, and returns the
+// pieces a test needs to drive the bridge.
+func startStream(t *testing.T, ctx context.Context, id string) (srv *fakeStreamServer, vmSide net.Conn, done <-chan error) {
+	t.Helper()
+
+	shimSide, vm := net.Pipe()
+	t.Cleanup(func() {
+		shimSide.Close()
+		vm.Close()
+	})
+
+	srv = newFakeStreamServer(ctx)
+	srv.recvCh <- streamInitAny(t, id)
+
+	svc := &service{sb: &fakeSandbox{conn: shimSide}}
+
+	d := make(chan error, 1)
+	go func() { d <- svc.Stream(ctx, srv) }()
+
+	// Drain the ack the service sends right after StreamInit.
+	select {
+	case <-srv.sendCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream init ack")
+	}
+	return srv, vm, d
+}
+
+// TestStreamReturnsAfterVMEOFWithoutClientClose reproduces the deadlock
+// fixed by the surrounding change. In a unidirectional VM->client
+// transfer the client never issues CloseSend, so bridgeTTRPCToVM stays
+// blocked in srv.Recv() forever. When the VM signals end-of-stream with
+// a zero-length frame the handler must still return promptly so ttrpc
+// closes the server stream and the client unblocks; without the fix the
+// handler waits for both bridge directions and hangs indefinitely.
+func TestStreamReturnsAfterVMEOFWithoutClientClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, vmSide, done := startStream(t, ctx, "stream-eof")
+
+	// VM finishes work without sending any data and signals EOF with a
+	// zero-length frame. The fake server is intentionally left with
+	// nothing more to deliver via Recv, so bridgeTTRPCToVM remains
+	// blocked just like a real handler waiting on a quiet client.
+	if err := binary.Write(vmSide, binary.BigEndian, uint32(0)); err != nil {
+		t.Fatalf("write VM EOF marker: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Stream returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stream handler did not return after VM EOF; the client->server bridge is still blocked in srv.Recv() and the handler is waiting for both directions to finish")
+	}
+}
+
+// TestStreamReturnsWhenVMEOFAfterClientClose covers the case where the
+// client sends CloseSend first and the VM finishes shortly after. The
+// handler must still wait for the VM->client direction to drain before
+// returning so no in-flight server replies are lost.
+func TestStreamReturnsWhenVMEOFAfterClientClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, vmSide, done := startStream(t, ctx, "stream-client-close")
+
+	// Client closes its send side. bridgeTTRPCToVM observes io.EOF and
+	// writes the zero-length frame to the VM.
+	srv.closeRecv()
+
+	// Drain the EOF marker that bridgeTTRPCToVM forwards to the VM so
+	// the pipe write does not block.
+	go func() {
+		var n uint32
+		_ = binary.Read(vmSide, binary.BigEndian, &n)
+	}()
+
+	// Handler must NOT have returned yet — the VM->client direction is
+	// still open. Give it a brief moment to settle and confirm it is
+	// still running.
+	select {
+	case err := <-done:
+		t.Fatalf("Stream returned before VM EOF (err=%v)", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// VM signals end-of-stream; handler returns.
+	if err := binary.Write(vmSide, binary.BigEndian, uint32(0)); err != nil {
+		t.Fatalf("write VM EOF marker: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Stream returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stream handler did not return after VM EOF")
+	}
+}
+
+// TestStreamForwardsBothDirections is a sanity check that data still
+// moves through the bridge correctly so the regression coverage above
+// is not vacuous.
+func TestStreamForwardsBothDirections(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, vmSide, done := startStream(t, ctx, "stream-bidi")
+
+	// Client -> VM: enqueue payloads through the fake server's recv
+	// channel and confirm the VM peer reads them as length-prefixed
+	// proto Any frames.
+	payloads := [][]byte{[]byte("hello"), []byte("world")}
+	for _, p := range payloads {
+		srv.recvCh <- &anypb.Any{TypeUrl: "test/bytes", Value: p}
+	}
+	for i, want := range payloads {
+		var n uint32
+		if err := binary.Read(vmSide, binary.BigEndian, &n); err != nil {
+			t.Fatalf("read frame %d length: %v", i, err)
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(vmSide, buf); err != nil {
+			t.Fatalf("read frame %d data: %v", i, err)
+		}
+		var got anypb.Any
+		if err := proto.Unmarshal(buf, &got); err != nil {
+			t.Fatalf("unmarshal frame %d: %v", i, err)
+		}
+		if !bytes.Equal(got.Value, want) {
+			t.Fatalf("VM frame %d = %q, want %q", i, got.Value, want)
+		}
+	}
+
+	// VM -> client: write framed messages and verify the client picks
+	// them up via Send.
+	replies := []string{"reply-1", "reply-2"}
+	for _, p := range replies {
+		frame := &anypb.Any{TypeUrl: "test/bytes", Value: []byte(p)}
+		data, err := proto.Marshal(frame)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := binary.Write(vmSide, binary.BigEndian, uint32(len(data))); err != nil {
+			t.Fatalf("write frame length: %v", err)
+		}
+		if _, err := vmSide.Write(data); err != nil {
+			t.Fatalf("write frame data: %v", err)
+		}
+	}
+	for _, want := range replies {
+		select {
+		case got := <-srv.sendCh:
+			if string(got.Value) != want {
+				t.Fatalf("client received %q, want %q", got.Value, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %q from server", want)
+		}
+	}
+
+	// VM signals EOF; handler must return without error.
+	if err := binary.Write(vmSide, binary.BigEndian, uint32(0)); err != nil {
+		t.Fatalf("write VM EOF: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Stream returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stream handler did not return after VM EOF")
+	}
+}

--- a/plugins/shim/streaming/plugin_test.go
+++ b/plugins/shim/streaming/plugin_test.go
@@ -20,8 +20,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -90,21 +94,33 @@ func (f *fakeStreamServer) Recv() (*anypb.Any, error) {
 	}
 }
 
+// SendMsg implements ttrpc.StreamServer. It is only invoked when a
+// caller goes through the generic ttrpc.StreamServer interface; the
+// streaming wrapper always passes *anypb.Any here. We assert that
+// explicitly and return a clear error on misuse instead of panicking.
 func (f *fakeStreamServer) SendMsg(m interface{}) error {
-	return f.Send(m.(*anypb.Any))
+	a, ok := m.(*anypb.Any)
+	if !ok {
+		return fmt.Errorf("fakeStreamServer.SendMsg: expected *anypb.Any, got %T", m)
+	}
+	return f.Send(a)
 }
 
+// RecvMsg implements ttrpc.StreamServer. The streaming wrapper always
+// passes a freshly-allocated *anypb.Any; we copy fields into it
+// directly rather than going through proto.Merge, which would silently
+// misbehave on a type mismatch.
 func (f *fakeStreamServer) RecvMsg(m interface{}) error {
+	dst, ok := m.(*anypb.Any)
+	if !ok {
+		return fmt.Errorf("fakeStreamServer.RecvMsg: expected *anypb.Any, got %T", m)
+	}
 	a, err := f.Recv()
 	if err != nil {
 		return err
 	}
-	dst, ok := m.(proto.Message)
-	if !ok {
-		return io.ErrUnexpectedEOF
-	}
-	proto.Reset(dst)
-	proto.Merge(dst, a)
+	dst.TypeUrl = a.TypeUrl
+	dst.Value = a.Value
 	return nil
 }
 
@@ -170,8 +186,7 @@ func startStream(t *testing.T, ctx context.Context, id string) (srv *fakeStreamS
 // closes the server stream and the client unblocks; without the fix the
 // handler waits for both bridge directions and hangs indefinitely.
 func TestStreamReturnsAfterVMEOFWithoutClientClose(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	_, vmSide, done := startStream(t, ctx, "stream-eof")
 
@@ -198,8 +213,7 @@ func TestStreamReturnsAfterVMEOFWithoutClientClose(t *testing.T) {
 // handler must still wait for the VM->client direction to drain before
 // returning so no in-flight server replies are lost.
 func TestStreamReturnsWhenVMEOFAfterClientClose(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	srv, vmSide, done := startStream(t, ctx, "stream-client-close")
 
@@ -241,8 +255,7 @@ func TestStreamReturnsWhenVMEOFAfterClientClose(t *testing.T) {
 // moves through the bridge correctly so the regression coverage above
 // is not vacuous.
 func TestStreamForwardsBothDirections(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	srv, vmSide, done := startStream(t, ctx, "stream-bidi")
 
@@ -309,5 +322,198 @@ func TestStreamForwardsBothDirections(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Stream handler did not return after VM EOF")
+	}
+}
+
+// fakeMultiSandbox returns a different net.Conn from StartStream for
+// each registered stream ID, allowing a single ttrpc connection to host
+// multiple streams with different VM-side behavior in the same test.
+type fakeMultiSandbox struct {
+	mu    sync.Mutex
+	conns map[string]net.Conn
+}
+
+func (s *fakeMultiSandbox) Start(context.Context, ...sandbox.Opt) error {
+	return errdefs.ErrNotImplemented
+}
+func (s *fakeMultiSandbox) Stop(context.Context) error     { return errdefs.ErrNotImplemented }
+func (s *fakeMultiSandbox) Client() (*ttrpc.Client, error) { return nil, errdefs.ErrNotImplemented }
+func (s *fakeMultiSandbox) StartStream(_ context.Context, id string) (net.Conn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	conn, ok := s.conns[id]
+	if !ok {
+		return nil, fmt.Errorf("stream %q: %w", id, errdefs.ErrNotFound)
+	}
+	delete(s.conns, id)
+	return conn, nil
+}
+
+// TestSlowStreamDoesNotBlockOtherStreams demonstrates the connection
+// receive-loop deadlock fixed by the ttrpc upgrade in go.mod (v1.2.8 ->
+// v1.2.9-...).
+//
+// In ttrpc v1.2.8 each server-side streamHandler has an unbuffered-ish
+// recv channel (cap=5) and `streamHandler.data` blocks indefinitely
+// when the channel is full. Because that function is called by the
+// single per-connection receive goroutine in server.go, a stream whose
+// handler is not draining its recv channel will block delivery for
+// every other stream and unary RPC sharing the same client connection.
+//
+// In ttrpc v1.2.9 the buffer size is 64 for client-streaming RPCs and
+// `data` falls back to a 1-second wait followed by ErrStreamFull, which
+// keeps the receive loop moving even when one stream stalls.
+//
+// To reproduce: open a stream whose VM-side connection is wedged so
+// the server's bridge consumes one message and then blocks on Write
+// forever. Burst >65 messages on the wire to fill the recv buffer
+// past the v1.2.9 cap, then open a second stream on the same client
+// and try to complete its init handshake. With the old ttrpc the
+// second stream's create+init request never reaches the handler;
+// with the new ttrpc the slow stream's surplus messages return
+// ErrStreamFull after ~1s and the second stream proceeds normally.
+func TestSlowStreamDoesNotBlockOtherStreams(t *testing.T) {
+	// VM-side conn for the "slow" stream: a synchronous net.Pipe whose
+	// VM end is never read, so the bridge's first Write blocks forever
+	// and subsequent client messages pile up in the stream's recv
+	// channel until it overflows.
+	slowShim, slowVM := net.Pipe()
+	t.Cleanup(func() {
+		slowShim.Close()
+		slowVM.Close()
+	})
+
+	// VM-side conn for the "fast" stream: drained eagerly so the
+	// handler can serve StreamInit and ack normally without back
+	// pressure.
+	fastShim, fastVM := net.Pipe()
+	t.Cleanup(func() {
+		fastShim.Close()
+		fastVM.Close()
+	})
+	go io.Copy(io.Discard, fastVM)
+
+	sb := &fakeMultiSandbox{
+		conns: map[string]net.Conn{
+			"slow": slowShim,
+			"fast": fastShim,
+		},
+	}
+
+	// Real ttrpc server with the streaming service registered.
+	server, err := ttrpc.NewServer()
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	streamapi.RegisterTTRPCStreamingService(server, &service{sb: sb})
+
+	// Stay under the AF_UNIX 104-byte sun_path limit on darwin:
+	// t.TempDir() on macOS lives under /var/folders/.../T/<TestName>/NNN/
+	// which alone exceeds 90 characters, so "<tmpdir>/ttrpc.sock"
+	// bind() with EINVAL there. Anchor the socket under /tmp instead
+	// (works on darwin and linux) and clean it up explicitly.
+	sockDir, err := os.MkdirTemp("/tmp", "nb-stream")
+	if err != nil {
+		t.Fatalf("mkdir tmp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(sockDir) })
+	sock := filepath.Join(sockDir, "s")
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		if err := server.Serve(serveCtx, listener); err != nil &&
+			!errors.Is(err, ttrpc.ErrServerClosed) {
+			t.Errorf("Serve: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		// Closing the slow pipes first lets any blocked bridge writes
+		// return so the streamHandler can finish and the receive loop
+		// unblocks before we tear down the server.
+		slowShim.Close()
+		slowVM.Close()
+		server.Close()
+		serveCancel()
+		<-serveDone
+	})
+
+	// ttrpc client over the same unix socket.
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := ttrpc.NewClient(conn)
+	t.Cleanup(func() { client.Close() })
+
+	streamClient := streamapi.NewTTRPCStreamingClient(client)
+
+	ctx := t.Context()
+
+	// 1) Open the slow stream and complete its init handshake. The
+	//    server's handler returns the slow shimSide conn from
+	//    StartStream and starts its bridge goroutines; the bridge
+	//    consumes the first data message we send below and then
+	//    blocks forever on Write to slowShim.
+	slow, err := streamClient.Stream(ctx)
+	if err != nil {
+		t.Fatalf("open slow stream: %v", err)
+	}
+	if err := slow.Send(streamInitAny(t, "slow")); err != nil {
+		t.Fatalf("send slow init: %v", err)
+	}
+	if _, err := slow.Recv(); err != nil {
+		t.Fatalf("slow ack: %v", err)
+	}
+
+	// 2) Burst messages on the slow stream until the server-side recv
+	//    buffer overflows. With ttrpc v1.2.8 the buffer is 5, so any
+	//    one of these will eventually wedge the connection's receive
+	//    loop. With v1.2.9 the buffer is 64; we send a few more to
+	//    push past it and trigger the 1-second ErrStreamFull fallback.
+	//    66 = 1 consumed by the bridge + 64 buffered + 1 to overflow.
+	payload := &anypb.Any{TypeUrl: "test/x", Value: bytes.Repeat([]byte{0xff}, 16)}
+	for i := 0; i < 66; i++ {
+		if err := slow.Send(payload); err != nil {
+			// v1.2.9+ closes the stream with a status error after the
+			// buffer-full event; further Sends will fail. By that
+			// point the deadlock has already been provoked.
+			break
+		}
+	}
+
+	// 3) Open a second stream on the same client and complete its
+	//    init handshake. With ttrpc v1.2.8 the create+init messages
+	//    sit on the wire because the server's connection-wide receive
+	//    goroutine is blocked delivering data to the slow stream's
+	//    full recv buffer. With v1.2.9 the slow stream's surplus
+	//    messages time out after ~1s with ErrStreamFull and the
+	//    receive loop continues to process this stream.
+	fast, err := streamClient.Stream(ctx)
+	if err != nil {
+		t.Fatalf("open fast stream: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		if err := fast.Send(streamInitAny(t, "fast")); err != nil {
+			done <- fmt.Errorf("send fast init: %w", err)
+			return
+		}
+		_, err := fast.Recv()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("fast stream init failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("fast stream init deadlocked: the slow stream's full recv buffer is blocking the connection's shared receive goroutine, so the fast stream's create+init request never reaches its handler. This is the deadlock fixed by upgrading ttrpc to v1.2.9 (per-stream recv buffer + ErrStreamFull fallback)")
 	}
 }


### PR DESCRIPTION
Change logic to close after server has finished rather than waiting for both ends, fixing a potential deadlock. Since the client will always initiate requests, the server finishing indicates there is no valid transactions of data.

Update the ttrpc server to avoid client connection deadlock when a stream is not fully received.