### PR TITLE
ci: run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,30 @@ jobs:
         working-directory: src/github.com/containerd/nerdbox
 
   #
+  # Unit tests
+  #
+  unit-tests:
+    name: Unit Tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: '.github/.tool-versions'
+
+      - name: Run unit tests
+        shell: bash
+        run: make test-unit
+
+  #
   # Protobuf checks
   #
   protos:

--- a/plugins/shim/streaming/plugin_test.go
+++ b/plugins/shim/streaming/plugin_test.go
@@ -407,12 +407,12 @@ func TestSlowStreamDoesNotBlockOtherStreams(t *testing.T) {
 	}
 	streamapi.RegisterTTRPCStreamingService(server, &service{sb: sb})
 
-	// Stay under the AF_UNIX 104-byte sun_path limit on darwin:
-	// t.TempDir() on macOS lives under /var/folders/.../T/<TestName>/NNN/
-	// which alone exceeds 90 characters, so "<tmpdir>/ttrpc.sock"
-	// bind() with EINVAL there. Anchor the socket under /tmp instead
-	// (works on darwin and linux) and clean it up explicitly.
-	sockDir, err := os.MkdirTemp("/tmp", "nb-stream")
+	// Stay under the AF_UNIX 104-byte sun_path limit on macOS:
+	// t.TempDir() embeds the full test name, pushing the path over the
+	// limit. os.MkdirTemp("", ...) uses os.TempDir() which produces a
+	// short numeric-only subdirectory (~70 chars on macOS) and the correct
+	// system temp dir on Windows.
+	sockDir, err := os.MkdirTemp("", "nb-stream")
 	if err != nil {
 		t.Fatalf("mkdir tmp: %v", err)
 	}


### PR DESCRIPTION
This change adds:
1. unit tests to CI on macOS, Linux, Windows
2. fixes temp directory unit test issue on Windows