### PR TITLE
vm/libkrun: pass trace level to krun_init_log when RUST_LOG is set

### DIFF
--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -125,7 +125,18 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 
 	var ret int32
 	setLogging.Do(func() {
-		ret = lib.InitLog(os.Stderr.Fd(), uint32(warnLevel), 0, 0)
+		// When RUST_LOG is set, pass trace level so libkrun's
+		// `log::set_max_level` does not cap below the env_logger filter
+		// parsed from RUST_LOG. The default `warnLevel` silently drops
+		// every `log::debug!`/`info!`/`trace!` from libkrun (and
+		// embedded Rust components such as virtio-net) before
+		// env_logger can emit it. Production behaviour with RUST_LOG
+		// unset is unchanged.
+		level := warnLevel
+		if _, ok := os.LookupEnv("RUST_LOG"); ok {
+			level = traceLevel
+		}
+		ret = lib.InitLog(os.Stderr.Fd(), uint32(level), 0, 0)
 	})
 	if ret != 0 {
 		return nil, fmt.Errorf("krun_init_log failed: %d", ret)

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -45,7 +45,8 @@ const (
 type logLevel uint32
 
 const (
-	warnLevel logLevel = 2
+	warnLevel  logLevel = 2
+	traceLevel logLevel = 5
 )
 
 type vmcontext struct {


### PR DESCRIPTION
## Summary

`krun_init_log` is currently always called with `warnLevel` (2). That value is forwarded to libkrun's `log::set_max_level`, which acts as a **hard cap on the `log` crate before env_logger evaluates the `RUST_LOG` filter**. Concretely, every `log::debug!` / `log::info!` / `log::trace!` emitted by libkrun (and by Rust components linked into it, such as virtio-net or virtio-fs) is dropped at the source — setting `RUST_LOG=debug` on the shim therefore produces no output below warn, even with a debug build.

This change makes the level dynamic:

- If `RUST_LOG` is **unset** (default / production), keep `warnLevel`. No behaviour change.
- If `RUST_LOG` is **set** (operator opted into debug logging), pass a new `traceLevel` (5). The libkrun cap is then effectively disabled and env_logger becomes the authoritative filter, parsed from `RUST_LOG` syntax as users expect.

The `traceLevel` constant is added next to `warnLevel` in `internal/vm/libkrun/krun.go`. The level selection lives at the single existing `lib.InitLog(...)` call site in `internal/vm/libkrun/instance.go`, inside `setLogging.Do(...)`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Build the shim with this change on Windows / Linux and confirm with `RUST_LOG=info,virtio_net=debug` exported into the shim process, libkrun + virtio-net log lines now appear on the shim's stderr stream (file descriptor passed to `krun_init_log`).
- [ ] Build with `RUST_LOG` unset, confirm output is identical to before this change (warn-and-above only).
