### PR TITLE
Add 4 more integration tests to run with make test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,4 +265,4 @@ jobs:
           _output/userns-check
 
       - name: Run integration tests
-        run: go test -v ./integration/...
+        run: make test-integration

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -31,8 +31,12 @@ fi
 # Run each test individually
 tests=(
     "TestSystemInfo"
+    "TestConsoleOutput"
+    "TestBootDiagnostics"
     "TestStreamInitialization"
     "TestTransferEcho"
+    "TestShimStart"
+    "TestShimConnect"
 )
 
 for test in "${tests[@]}"; do


### PR DESCRIPTION
The test.sh is used to run each test in its own process to prevent shutdown issues on some platforms.