### PR TITLE
Remove shim socket earlier in shutdown

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -70,12 +70,6 @@ func NewTaskService(ctx context.Context, sb sandbox.Sandbox, publisher shim.Publ
 	}
 	sd.RegisterCallback(s.shutdown)
 
-	if address, err := shim.ReadAddress("address"); err == nil {
-		sd.RegisterCallback(func(context.Context) error {
-			return shim.RemoveSocket(address)
-		})
-	}
-
 	go s.forward(ctx, publisher)
 
 	return s, nil
@@ -714,6 +708,12 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 		// for cleanup before calling shutdown
 		s.initiateShutdown()
 		s.initiateShutdown = nil
+
+		// Remove the shim socket so that if shutdown is slow, containerd doesn't try to
+		// re-use this shim.
+		if address, err := shim.ReadAddress("address"); err == nil {
+			shim.RemoveSocket(address)
+		}
 	}
 
 	return empty, nil


### PR DESCRIPTION
Containerd tests the shim's socket for liveness when deciding whether to launch a new shim process or re-use an existing one. The shim didn't remove the socket until shutdown was complete. However, if shutdown is not fast enogh (e.g. because it is unmounting and flushing dirty pages to virtio-block devices), then there is a window in which containerd can try to schedule new tasks onto a shim that is shutting down.

This fixes that issue by eagerly removing the shim socket as soon as shutdown starts. Existing connections still work, but new connections will fail which prevents containerd from reusing the shim.