### PR TITLE
Make Shutdown ttrpc synchronous to close shim-reuse race

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -67,6 +67,7 @@ func NewTaskService(ctx context.Context, sb sandbox.Sandbox, publisher shim.Publ
 		containers:       make(map[string]*container),
 		debug:            debug,
 		initiateShutdown: sd.Shutdown,
+		shutdownDone:     sd.Done(),
 	}
 	sd.RegisterCallback(s.shutdown)
 
@@ -124,8 +125,10 @@ type service struct {
 
 	containers map[string]*container
 
-	debug            bool
-	initiateShutdown func()
+	debug                bool
+	initiateShutdown     func()
+	initiateShutdownOnce sync.Once
+	shutdownDone         <-chan struct{}
 }
 
 func (s *service) RegisterTTRPC(server *ttrpc.Server) error {
@@ -706,17 +709,14 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 	// tc := taskAPI.NewTTRPCTaskClient(s.vm.Client())
 	// return tc.Shutdown(ctx, r)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.initiateShutdownOnce.Do(s.initiateShutdown)
 
-	if s.initiateShutdown != nil {
-		// please make sure that temporary resource has been cleanup or registered
-		// for cleanup before calling shutdown
-		s.initiateShutdown()
-		s.initiateShutdown = nil
+	select {
+	case <-s.shutdownDone:
+		return empty, nil
+	case <-ctx.Done():
+		return nil, errgrpc.ToGRPC(ctx.Err())
 	}
-
-	return empty, nil
 }
 
 func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*taskAPI.StatsResponse, error) {


### PR DESCRIPTION
The Shutdown ttrpc returned as soon as the shutdown service was triggered, leaving the shim socket bound and connectable while async cleanup ran. Containerd's shim manager treats a connectable socket at the expected address as a live shim to reuse, so a fresh task started with the same id immediately after the previous one exited could be bound to the dying shim.

Block Shutdown on shutdown.Service.Done() so the response is not sent until cleanup callbacks (including socket removal) have completed. Containerd's 3s shutdownTimeout is respected by also selecting on ctx.Done().

The wait is performed outside the service mutex: the s.shutdown callback itself acquires that mutex, so holding it across the wait would deadlock the callback against the channel it must close.