### PR TITLE
Acquire flock on shim.pid to wait for shim process to exit

### DIFF
--- a/pkg/shim/manager/manager_unix.go
+++ b/pkg/shim/manager/manager_unix.go
@@ -20,7 +20,9 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -186,6 +188,31 @@ func (manager) Start(ctx context.Context, bparams *bootapi.BootstrapParams) (_ *
 		cmd.ExtraFiles = append(cmd.ExtraFiles, s.f)
 	}
 
+	// Create a temp file in the same directory as shim.pid and acquire an
+	// exclusive flock on it.  The fd is handed to the shim via ExtraFiles so
+	// the OS keeps the lock alive for exactly the shim's lifetime; when the
+	// shim exits every fd referring to that file description is closed and the
+	// lock is automatically released.
+	pidPath, err := filepath.Abs("shim.pid")
+	if err != nil {
+		return nil, fmt.Errorf("shim.pid abs path: %w", err)
+	}
+	pidTmpFile, err := os.CreateTemp(filepath.Dir(pidPath), ".shim.pid.")
+	if err != nil {
+		return nil, fmt.Errorf("create pid temp file: %w", err)
+	}
+	pidTmpName := pidTmpFile.Name()
+	defer func() {
+		if retErr != nil {
+			pidTmpFile.Close()
+			os.Remove(pidTmpName)
+		}
+	}()
+	if err := syscall.Flock(int(pidTmpFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return nil, fmt.Errorf("acquire flock on pid file: %w", err)
+	}
+	cmd.ExtraFiles = append(cmd.ExtraFiles, pidTmpFile)
+
 	userns := cloneMntNs(ctx, cmd)
 
 	if startErr := cmd.Start(); startErr != nil {
@@ -209,6 +236,7 @@ func (manager) Start(ctx context.Context, bparams *bootapi.BootstrapParams) (_ *
 		for _, s := range sockets {
 			cmd.ExtraFiles = append(cmd.ExtraFiles, s.f)
 		}
+		cmd.ExtraFiles = append(cmd.ExtraFiles, pidTmpFile)
 		if err := cmd.Start(); err != nil {
 			return nil, fmt.Errorf("retry without userns failed: %w (original error: %v)", err, startErr)
 		}
@@ -222,36 +250,26 @@ func (manager) Start(ctx context.Context, bparams *bootapi.BootstrapParams) (_ *
 	// make sure to wait after start
 	go cmd.Wait()
 
-	/*
-		if opts, err := shim.ReadRuntimeOptions[*options.Options](os.Stdin); err == nil {
-				if opts.ShimCgroup != "" {
-					if cgroups.Mode() == cgroups.Unified {
-						cg, err := cgroupsv2.Load(opts.ShimCgroup)
-						if err != nil {
-							return nil, fmt.Errorf("failed to load cgroup %s: %w", opts.ShimCgroup, err)
-						}
-						if err := cg.AddProc(uint64(cmd.Process.Pid)); err != nil {
-							return nil, fmt.Errorf("failed to join cgroup %s: %w", opts.ShimCgroup, err)
-						}
-					} else {
-						cg, err := cgroup1.Load(cgroup1.StaticPath(opts.ShimCgroup))
-						if err != nil {
-							return nil, fmt.Errorf("failed to load cgroup %s: %w", opts.ShimCgroup, err)
-						}
-						if err := cg.AddProc(uint64(cmd.Process.Pid)); err != nil {
-							return nil, fmt.Errorf("failed to join cgroup %s: %w", opts.ShimCgroup, err)
-						}
-					}
-				}
-		}
+	// TODO: Consider runtime options to supporting adding the shim into a cgroup
 
-		if err := shim.AdjustOOMScore(cmd.Process.Pid); err != nil {
-			return nil, fmt.Errorf("failed to adjust OOM score for shim: %w", err)
-		}
-	*/
+	if err := shim.AdjustOOMScore(cmd.Process.Pid); err != nil {
+		return nil, fmt.Errorf("failed to adjust OOM score for shim: %w", err)
+	}
 
-	if err = shim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
-		return nil, err
+	// Write the PID into the temp file, sync it to disk, close the parent's
+	// copy of the fd (the shim child keeps its inherited copy and therefore
+	// holds the flock), then atomically rename to the final "shim.pid" path.
+	if _, err := fmt.Fprintf(pidTmpFile, "%d", cmd.Process.Pid); err != nil {
+		return nil, fmt.Errorf("write pid: %w", err)
+	}
+	if err := pidTmpFile.Sync(); err != nil {
+		return nil, fmt.Errorf("sync pid file: %w", err)
+	}
+	if err := pidTmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("close pid file: %w", err)
+	}
+	if err := os.Rename(pidTmpName, pidPath); err != nil {
+		return nil, fmt.Errorf("rename pid file: %w", err)
 	}
 
 	return &bootapi.BootstrapResult{
@@ -262,55 +280,57 @@ func (manager) Start(ctx context.Context, bparams *bootapi.BootstrapParams) (_ *
 }
 
 func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
-	p, err := os.ReadFile("shim.pid")
+	pid, err := waitForShimPidLock()
 	if err != nil {
 		return shim.StopStatus{}, err
 	}
-	pid, err := strconv.Atoi(string(p))
-	if err != nil {
-		return shim.StopStatus{}, err
-	}
-	/*
-		cwd, err := os.Getwd()
-		if err != nil {
-			return shim.StopStatus{}, err
-		}
-
-		path := filepath.Join(filepath.Dir(cwd), id)
-		ns, err := namespaces.NamespaceRequired(ctx)
-		if err != nil {
-			return shim.StopStatus{}, err
-		}
-		runtime, err := runc.ReadRuntime(path)
-		if err != nil && !os.IsNotExist(err) {
-			return shim.StopStatus{}, err
-		}
-		opts, err := runc.ReadOptions(path)
-		if err != nil {
-			return shim.StopStatus{}, err
-		}
-		root := process.RuncRoot
-		if opts != nil && opts.Root != "" {
-			root = opts.Root
-		}
-
-		r := process.NewRunc(root, path, ns, runtime, false)
-		if err := r.Delete(ctx, id, &runcC.DeleteOpts{
-			Force: true,
-		}); err != nil {
-			log.G(ctx).WithError(err).Warn("failed to remove runc container")
-		}
-		if err := mount.UnmountRecursive(filepath.Join(path, "rootfs"), 0); err != nil {
-			log.G(ctx).WithError(err).Warn("failed to cleanup rootfs mount")
-		}
-		pid, err := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
-		if err != nil {
-			log.G(ctx).WithError(err).Warn("failed to read init pid file")
-		}
-	*/
 	return shim.StopStatus{
 		ExitedAt:   time.Now(),
 		ExitStatus: 128 + int(unix.SIGKILL),
 		Pid:        pid,
 	}, nil
+}
+
+// waitForShimPidLock opens shim.pid, reads the shim PID, and blocks until the
+// shim process releases the exclusive flock it holds on that file (i.e. until
+// the shim exits). It returns the PID on success.
+//
+// The shim is the only process that acquires the lock, so after SIGKILL it will
+// inevitably exit and release it. Blocking unconditionally — rather than racing
+// against a timeout — guarantees the caller does not return while the shim is
+// still alive.
+func waitForShimPidLock() (int, error) {
+	f, err := os.Open("shim.pid")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	p, err := io.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(p)))
+	if err != nil {
+		return 0, err
+	}
+
+	// Try a non-blocking acquire first. If it succeeds the shim has already
+	// exited and the lock is free.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+		return pid, nil
+	} else if !errors.Is(err, syscall.EWOULDBLOCK) {
+		return 0, fmt.Errorf("flock shim.pid: %w", err)
+	}
+
+	// Lock is held — shim is still running. Kill it and block until the OS
+	// releases the lock on shim exit. There is no timeout: the shim cannot
+	// hold the lock after it dies, and returning early would leave it alive.
+	if kerr := unix.Kill(pid, unix.SIGKILL); kerr != nil && !errors.Is(kerr, unix.ESRCH) {
+		return 0, fmt.Errorf("kill shim: %w", kerr)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return 0, fmt.Errorf("flock shim.pid (wait): %w", err)
+	}
+	return pid, nil
 }

--- a/pkg/shim/manager/manager_windows.go
+++ b/pkg/shim/manager/manager_windows.go
@@ -21,11 +21,13 @@ package manager
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -33,6 +35,7 @@ import (
 	bootapi "github.com/containerd/containerd/api/runtime/bootstrap/v1"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/shim"
+	"golang.org/x/sys/windows"
 )
 
 func newCommand(ctx context.Context, id, containerdAddress, containerdTTRPCAddress string, debug bool) (*exec.Cmd, error) {
@@ -159,13 +162,50 @@ func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
 	if err != nil {
 		return shim.StopStatus{}, err
 	}
-	pid, err := strconv.Atoi(string(p))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(p)))
 	if err != nil {
 		return shim.StopStatus{}, err
 	}
+
+	// Open the shim process with the rights needed to terminate it, wait for
+	// it to exit, and read its exit code. If OpenProcess fails with
+	// ERROR_INVALID_PARAMETER the PID is no longer in the process table —
+	// the shim has already exited.
+	h, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|windows.SYNCHRONIZE,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			// Process already gone.
+			return shim.StopStatus{
+				ExitedAt:   time.Now(),
+				ExitStatus: 128 + 9,
+				Pid:        pid,
+			}, nil
+		}
+		return shim.StopStatus{}, fmt.Errorf("open shim process: %w", err)
+	}
+	defer windows.CloseHandle(h)
+
+	// Terminate the shim. ERROR_ACCESS_DENIED is returned when the process
+	// has already exited but the handle is still open; WaitForSingleObject
+	// below will return immediately in that case.
+	if err := windows.TerminateProcess(h, uint32(128+9)); err != nil && !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		return shim.StopStatus{}, fmt.Errorf("terminate shim process: %w", err)
+	}
+
+	// Block until the process has fully exited. There is no timeout: the
+	// shim is the only target and TerminateProcess is unconditional, so
+	// WaitForSingleObject will always complete.
+	if _, err := windows.WaitForSingleObject(h, windows.INFINITE); err != nil {
+		return shim.StopStatus{}, fmt.Errorf("wait for shim process: %w", err)
+	}
+
 	return shim.StopStatus{
 		ExitedAt:   time.Now(),
-		ExitStatus: 128 + 9, // 128 + SIGKILL
+		ExitStatus: 128 + 9,
 		Pid:        pid,
 	}, nil
 }


### PR DESCRIPTION
When shim delete is called today, currently there is no check or guarantee that the shim process has exited before returning. If the flock would be held, send a kill signal to the pid and then block to acquire flock.

Depends on #183 to ensure the when shim delete is called, the shim is still not doing important cleanup tasks. When shim delete is called, the shim should be dead or ready to be killed.