### PR TITLE
Remove shim socket earlier in shutdown

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -71,12 +71,6 @@ func NewTaskService(ctx context.Context, sb sandbox.Sandbox, publisher shim.Publ
 	}
 	sd.RegisterCallback(s.shutdown)
 
-	if address, err := shim.ReadAddress("address"); err == nil {
-		sd.RegisterCallback(func(context.Context) error {
-			return shim.RemoveSocket(address)
-		})
-	}
-
 	go s.forward(ctx, publisher)
 
 	return s, nil
@@ -710,6 +704,12 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 	// return tc.Shutdown(ctx, r)
 
 	s.initiateShutdownOnce.Do(s.initiateShutdown)
+
+	// Remove the shim socket so that if shutdown is slow, containerd doesn't try to
+	// re-use this shim.
+	if address, err := shim.ReadAddress("address"); err == nil {
+		shim.RemoveSocket(address)
+	}
 
 	select {
 	case <-s.shutdownDone:


### PR DESCRIPTION
Containerd tests the shim's socket for liveness when deciding whether to launch a new shim process or re-use an existing one. The shim didn't remove the socket until shutdown was complete. If shutdown is slow (e.g. unmounting and flushing dirty pages to virtio-block devices), there is a window where containerd can schedule new tasks onto a shutting-down shim.

This removes the shim socket eagerly as soon as `Shutdown` is invoked. Existing connections still work, but new connections fail — preventing containerd from reusing the shim.

Note: this overlaps with #183 (synchronous Shutdown ttrpc), which closes the same race for the post-`Shutdown`-response path. The eager removal here is defense-in-depth for any code path that probes socket liveness while shutdown is in flight.

Duplicate of #182 — opened to carry the change on top of current `main` after #183 landed.