### PR TITLE
vminit/initd: add ExtraServerInterceptors hook

### DIFF
--- a/pkg/vminit/initd/initd.go
+++ b/pkg/vminit/initd/initd.go
@@ -53,6 +53,12 @@ import (
 // logLevel controls the slog handler level for vminitd.
 var logLevel = &slog.LevelVar{}
 
+// ExtraServerInterceptors are chained after the default otelttrpc interceptor
+// when the vminitd ttrpc server starts. Callers may append to this slice from
+// a package init() function before initd.Run is called to inject additional
+// server-side interceptors (e.g. for distributed tracing).
+var ExtraServerInterceptors []ttrpc.UnaryServerInterceptor
+
 func init() {
 	log.UseSlog()
 	// Write structured logs to /dev/console rather than stderr so that
@@ -294,7 +300,9 @@ func newService(ctx context.Context, config Config, shutdownSvc shutdown.Service
 	})
 
 	ts, err := ttrpc.NewServer(
-		ttrpc.WithUnaryServerInterceptor(otelttrpc.UnaryServerInterceptor()),
+		ttrpc.WithChainUnaryServerInterceptor(
+			append([]ttrpc.UnaryServerInterceptor{otelttrpc.UnaryServerInterceptor()},
+				ExtraServerInterceptors...)...),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
After the recent refactoring of the `main.go` functions (e.g. #185) it's possible to hook in tracing (like https://github.com/containerd/nerdbox/pull/139 )

The only missing piece is some spans from `initd`. Fix by allowing callers to inject additional `ttrpc.UnaryServerInterceptors` into the vminitd ttrpc server alongside the default otelttrpc interceptor. Callers append to `ExtraServerInterceptors` from a package `init()` function before `initd.Run` is called.

