### PR TITLE
Remove unmount timeout on shutdown

### DIFF
--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -154,10 +154,7 @@ func (s *service) shutdown(ctx context.Context) error {
 		if vmc, err := s.sb.Client(); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to get VM client; skipping unmount of block volumes before VM shutdown")
 		} else {
-			unmountCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			err := unmountAllWithRetry(unmountCtx, mountAPI.NewTTRPCMountClient(vmc))
-			cancel()
-			if err != nil {
+			if err := unmountAllWithRetry(ctx, mountAPI.NewTTRPCMountClient(vmc)); err != nil {
 				log.G(ctx).WithError(err).Warn("failed to unmount all block volumes before VM shutdown")
 			}
 		}


### PR DESCRIPTION
UnmountAllWithRetries set it's own 30s timeout, but it's covered by the overall shutdown timeout. Setting a distinct timeout for unmount makes it harder to trace exactly which timeout expired if shutdown takes too long. Instead, we should treat the whole shutdown process as a single process covered by a single timeout.