### PR TITLE
Propagate read-only flag for virtiofs bind mounts

### DIFF
--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -211,6 +211,7 @@ type bindMount struct {
 	tag      string
 	hostSrc  string
 	vmTarget string
+	readOnly bool
 }
 
 func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
@@ -242,10 +243,24 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 			specSrc = path.Join(vmTarget, filepath.Base(m.Source))
 		}
 
+		// Honor a read-only request from the OCI spec by marking the
+		// virtiofs share read-only at the host edge. The guest still
+		// applies the `ro` mount option to enforce read-only inside the
+		// container; this flag is defense in depth and ensures the host
+		// also rejects writes when the underlying libkrun supports it.
+		readOnly := false
+		for _, opt := range m.Options {
+			if opt == "ro" {
+				readOnly = true
+				break
+			}
+		}
+
 		transformed := bindMount{
 			tag:      tag,
 			hostSrc:  hostSrc,
 			vmTarget: vmTarget,
+			readOnly: readOnly,
 		}
 
 		bm.mounts = append(bm.mounts, transformed)
@@ -258,7 +273,7 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 func (bm *bindMounter) SandboxOpts() []sandbox.Opt {
 	var opts []sandbox.Opt
 	for _, m := range bm.mounts {
-		opts = append(opts, sandbox.WithFS(m.tag, m.hostSrc, false))
+		opts = append(opts, sandbox.WithFS(m.tag, m.hostSrc, m.readOnly))
 	}
 	return opts
 }

--- a/internal/shim/task/mount_test.go
+++ b/internal/shim/task/mount_test.go
@@ -178,6 +178,7 @@ func TestBindMountsProvider(t *testing.T) {
 		wantMounts      []bindMount
 		wantSpecSources []string // expected sources in the OCI spec after transformation
 		wantVmMounts    []mount.Mount
+		wantFS          []sandbox.Filesystem
 	}{
 		{
 			name:            "no mounts",
@@ -212,12 +213,57 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+			},
+		},
+		{
+			name: "single bind mount read-only",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testdirData, Destination: "/container/data", Options: []string{"rbind", "ro"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-8c5eaa445dd84f17",
+					hostSrc:  testdirData,
+					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					readOnly: true,
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: true},
+			},
+		},
+		{
+			name: "single file bind mount read-only",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testfile, Destination: "/container/testfile", Options: []string{"bind", "ro"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-6dace5108a719565",
+					hostSrc:  tmpDir,
+					vmTarget: "/mnt/bind-6dace5108a719565",
+					readOnly: true,
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: true},
+			},
 		},
 		{
 			name: "multiple bind mounts",
 			mounts: []specs.Mount{
 				{Type: "bind", Source: testdirData, Destination: "/container/data"},
-				{Type: "bind", Source: testdirConfig, Destination: "/container/config"},
+				{Type: "bind", Source: testdirConfig, Destination: "/container/config", Options: []string{"rbind", "ro"}},
 			},
 			wantMounts: []bindMount{
 				{
@@ -229,6 +275,7 @@ func TestBindMountsProvider(t *testing.T) {
 					tag:      "bind-529984c9ac58b7ec",
 					hostSrc:  testdirConfig,
 					vmTarget: "/mnt/bind-529984c9ac58b7ec",
+					readOnly: true,
 				},
 			},
 			wantSpecSources: []string{
@@ -238,6 +285,10 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 				{Type: "virtiofs", Source: "bind-529984c9ac58b7ec", Target: "/mnt/bind-529984c9ac58b7ec"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+				{Tag: "bind-529984c9ac58b7ec", MountPath: testdirConfig, Readonly: true},
 			},
 		},
 		{
@@ -262,6 +313,9 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+			},
 		},
 		{
 			name: "single file bind mount",
@@ -278,6 +332,9 @@ func TestBindMountsProvider(t *testing.T) {
 			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: false},
 			},
 		},
 	}
@@ -302,6 +359,10 @@ func TestBindMountsProvider(t *testing.T) {
 
 			// Verify the VM mounts passed via MountAll RPC
 			assert.Equal(t, tc.wantVmMounts, bm.VmMounts())
+
+			// Verify the sandbox.Filesystem entries (and their
+			// Readonly flag) flow correctly through SandboxOpts.
+			assert.Equal(t, tc.wantFS, applyOpts(bm.SandboxOpts()).Filesystems)
 		})
 	}
 }

--- a/internal/vm/libkrun/dlfcn_unix.go
+++ b/internal/vm/libkrun/dlfcn_unix.go
@@ -31,3 +31,16 @@ func dlClose(handle uintptr) error {
 func registerLibFunc(fn interface{}, handle uintptr, name string) {
 	purego.RegisterLibFunc(fn, handle, name)
 }
+
+// registerOptionalLibFunc resolves name in the library handle and binds fn
+// to it when present. It returns false (without panicking) when the symbol
+// is not exported, so callers can leave the function pointer nil and probe
+// for it at call time.
+func registerOptionalLibFunc(fn interface{}, handle uintptr, name string) bool {
+	addr, err := purego.Dlsym(handle, name)
+	if err != nil || addr == 0 {
+		return false
+	}
+	purego.RegisterFunc(fn, addr)
+	return true
+}

--- a/internal/vm/libkrun/dlfcn_windows.go
+++ b/internal/vm/libkrun/dlfcn_windows.go
@@ -52,3 +52,16 @@ func registerLibFunc(fn interface{}, handle uintptr, name string) {
 	}
 	purego.RegisterFunc(fn, addr)
 }
+
+// registerOptionalLibFunc resolves name in the library handle and binds fn
+// to it when present. It returns false (without panicking) when the symbol
+// is not exported, so callers can leave the function pointer nil and probe
+// for it at call time.
+func registerOptionalLibFunc(fn interface{}, handle uintptr, name string) bool {
+	addr, err := syscall.GetProcAddress(syscall.Handle(handle), name)
+	if err != nil || addr == 0 {
+		return false
+	}
+	purego.RegisterFunc(fn, uintptr(addr))
+	return true
+}

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -174,7 +174,12 @@ func (v *vmInstance) AddFS(ctx context.Context, tag, mountPath string, opts ...v
 
 	// TODO: Cannot be started?
 
-	if err := v.vmc.AddVirtiofs(tag, mountPath); err != nil {
+	var mc vm.MountConfig
+	for _, o := range opts {
+		o(&mc)
+	}
+
+	if err := v.vmc.AddVirtiofs(ctx, tag, mountPath, mc.Readonly); err != nil {
 		return fmt.Errorf("failed to add virtiofs tag:%s mount:%s: %w", tag, mountPath, err)
 	}
 

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -17,12 +17,15 @@
 package libkrun
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"reflect"
 	"runtime"
 	"strings"
 	"unsafe"
+
+	"github.com/containerd/log"
 
 	"github.com/containerd/nerdbox/pkg/vm"
 )
@@ -146,13 +149,32 @@ func (vmc *vmcontext) AddVSockPortConnect(port uint32, path string) error {
 	return nil
 }
 
-func (vmc *vmcontext) AddVirtiofs(tag, path string) error {
+// AddVirtiofs attaches a virtio-fs share to the VM. When readonly is true
+// it prefers krun_add_virtiofs3 (libkrun >= 1.18) which natively marks the
+// share read-only at the host edge. If that symbol is not exported by the
+// loaded libkrun, it falls back to krun_add_virtiofs and emits a warning:
+// in that case the read-only enforcement relies on the guest applying the
+// `ro` mount option, which the OCI spec already carries.
+func (vmc *vmcontext) AddVirtiofs(ctx context.Context, tag, path string, readonly bool) error {
+	if vmc.lib.AddVirtiofs3 != nil {
+		ret := vmc.lib.AddVirtiofs3(vmc.ctxID, tag, path, 0, readonly)
+		if ret != 0 {
+			return fmt.Errorf("krun_add_virtiofs3 failed: %d", ret)
+		}
+		return nil
+	}
 	if vmc.lib.AddVirtiofs == nil {
 		return fmt.Errorf("libkrun not loaded")
 	}
+	if readonly {
+		log.G(ctx).WithField("tag", tag).Warn(
+			"libkrun does not export krun_add_virtiofs3; " +
+				"read-only virtiofs enforcement deferred to the guest mount options",
+		)
+	}
 	ret := vmc.lib.AddVirtiofs(vmc.ctxID, tag, path)
 	if ret != 0 {
-		return fmt.Errorf("krun_add_virtio_fs failed: %d", ret)
+		return fmt.Errorf("krun_add_virtiofs failed: %d", ret)
 	}
 	return nil
 }
@@ -261,6 +283,7 @@ type libkrun struct {
 	StartEnter         func(ctxID uint32) int32                                                               `C:"krun_start_enter"`
 	AddVsockPort       func(ctxID, port uint32, path string, listen bool) int32                               `C:"krun_add_vsock_port2"`
 	AddVirtiofs        func(ctxID uint32, tag, path string) int32                                             `C:"krun_add_virtiofs"`
+	AddVirtiofs3       func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32              `C:"krun_add_virtiofs3,optional"`
 	GetShutdownEventfd func(ctxID uint32) int32                                                               `C:"krun_get_shutdown_eventfd"`
 	SetGpuOptions      func(ctxID, flag uint32) int32                                                         `C:"krun_set_gpu_options"`
 	SetGvproxyPath     func(ctxID uint32, path string) int32                                                  `C:"krun_set_gvproxy_path"`
@@ -284,6 +307,7 @@ type libkrun struct {
 		krun_add_vsock_port
 		krun_set_vm_config
 		krun_add_virtiofs2
+		krun_add_virtiofs3
 		krun_set_console_output
 		krun_set_env
 		krun_set_gvproxy_path
@@ -335,10 +359,32 @@ func openLibkrun(path string) (_ *libkrun, _ uintptr, retErr error) {
 	var k libkrun
 	ik := reflect.Indirect(reflect.ValueOf(&k))
 	for i := 0; i < ik.NumField(); i++ {
-		cName := ik.Type().Field(i).Tag.Get("C")
+		tag := ik.Type().Field(i).Tag.Get("C")
+		cName, optional := parseCTag(tag)
 		fn := ik.Field(i).Addr().Interface()
+		if optional {
+			// registerOptionalLibFunc reports whether the symbol was
+			// resolved; if not, the field is left nil and call sites
+			// must guard against it.
+			registerOptionalLibFunc(fn, f, cName)
+			continue
+		}
 		registerLibFunc(fn, f, cName)
 	}
 
 	return &k, f, nil
+}
+
+// parseCTag splits a struct tag like `krun_foo` or `krun_foo,optional` into
+// the bare symbol name and an optional flag. Unknown trailing tokens are
+// ignored.
+func parseCTag(tag string) (name string, optional bool) {
+	parts := strings.Split(tag, ",")
+	name = parts[0]
+	for _, p := range parts[1:] {
+		if p == "optional" {
+			optional = true
+		}
+	}
+	return name, optional
 }

--- a/internal/vm/libkrun/krun_test.go
+++ b/internal/vm/libkrun/krun_test.go
@@ -1,0 +1,179 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package libkrun
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseCTag(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantOpt  bool
+	}{
+		{"krun_create_ctx", "krun_create_ctx", false},
+		{"krun_add_virtiofs3,optional", "krun_add_virtiofs3", true},
+		{"krun_foo,optional,bogus", "krun_foo", true},
+		{"krun_foo,bogus", "krun_foo", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			name, opt := parseCTag(c.in)
+			if name != c.wantName || opt != c.wantOpt {
+				t.Fatalf("parseCTag(%q) = (%q, %v), want (%q, %v)", c.in, name, opt, c.wantName, c.wantOpt)
+			}
+		})
+	}
+}
+
+// TestAddVirtiofs_PrefersV3 verifies that when libkrun exports
+// krun_add_virtiofs3, AddVirtiofs routes through it and forwards the
+// readonly flag without falling back to the legacy entry point.
+func TestAddVirtiofs_PrefersV3(t *testing.T) {
+	type v3Call struct {
+		tag      string
+		path     string
+		readonly bool
+	}
+	var v3Calls []v3Call
+	legacyCalled := false
+
+	lib := &libkrun{
+		AddVirtiofs3: func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32 {
+			v3Calls = append(v3Calls, v3Call{tag, path, readonly})
+			return 0
+		},
+		AddVirtiofs: func(ctxID uint32, tag, path string) int32 {
+			legacyCalled = true
+			return 0
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	if err := vmc.AddVirtiofs(context.Background(), "tag-ro", "/src/ro", true); err != nil {
+		t.Fatalf("readonly call: unexpected error: %v", err)
+	}
+	if err := vmc.AddVirtiofs(context.Background(), "tag-rw", "/src/rw", false); err != nil {
+		t.Fatalf("read-write call: unexpected error: %v", err)
+	}
+
+	if legacyCalled {
+		t.Fatalf("legacy AddVirtiofs was invoked while AddVirtiofs3 was available")
+	}
+	if len(v3Calls) != 2 {
+		t.Fatalf("expected 2 v3 calls, got %d", len(v3Calls))
+	}
+	if v3Calls[0] != (v3Call{tag: "tag-ro", path: "/src/ro", readonly: true}) {
+		t.Fatalf("first v3 call mismatch: %+v", v3Calls[0])
+	}
+	if v3Calls[1] != (v3Call{tag: "tag-rw", path: "/src/rw", readonly: false}) {
+		t.Fatalf("second v3 call mismatch: %+v", v3Calls[1])
+	}
+}
+
+// TestAddVirtiofs_FallsBackWhenV3Missing verifies that when the loaded
+// libkrun does not export krun_add_virtiofs3, AddVirtiofs falls back to
+// the legacy entry point. The readonly flag cannot be carried at the
+// host edge in that case but the call must still succeed; enforcement
+// is left to the guest mount options.
+func TestAddVirtiofs_FallsBackWhenV3Missing(t *testing.T) {
+	type legacyCall struct {
+		tag  string
+		path string
+	}
+	var legacyCalls []legacyCall
+
+	lib := &libkrun{
+		// AddVirtiofs3 intentionally nil.
+		AddVirtiofs: func(ctxID uint32, tag, path string) int32 {
+			legacyCalls = append(legacyCalls, legacyCall{tag, path})
+			return 0
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	if err := vmc.AddVirtiofs(context.Background(), "tag-ro", "/src/ro", true); err != nil {
+		t.Fatalf("readonly fallback: unexpected error: %v", err)
+	}
+	if err := vmc.AddVirtiofs(context.Background(), "tag-rw", "/src/rw", false); err != nil {
+		t.Fatalf("read-write fallback: unexpected error: %v", err)
+	}
+
+	if len(legacyCalls) != 2 {
+		t.Fatalf("expected 2 legacy calls, got %d", len(legacyCalls))
+	}
+	if legacyCalls[0] != (legacyCall{tag: "tag-ro", path: "/src/ro"}) {
+		t.Fatalf("first legacy call mismatch: %+v", legacyCalls[0])
+	}
+	if legacyCalls[1] != (legacyCall{tag: "tag-rw", path: "/src/rw"}) {
+		t.Fatalf("second legacy call mismatch: %+v", legacyCalls[1])
+	}
+}
+
+// TestAddVirtiofs_V3FailurePropagates ensures the libkrun return code
+// from krun_add_virtiofs3 surfaces as an error and is not silently
+// downgraded to the legacy path.
+func TestAddVirtiofs_V3FailurePropagates(t *testing.T) {
+	legacyCalled := false
+	lib := &libkrun{
+		AddVirtiofs3: func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32 {
+			return -22
+		},
+		AddVirtiofs: func(ctxID uint32, tag, path string) int32 {
+			legacyCalled = true
+			return 0
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	err := vmc.AddVirtiofs(context.Background(), "tag", "/p", true)
+	if err == nil {
+		t.Fatalf("expected error when krun_add_virtiofs3 returns non-zero")
+	}
+	if legacyCalled {
+		t.Fatalf("legacy AddVirtiofs must not be tried after krun_add_virtiofs3 failure")
+	}
+}
+
+// TestAddVirtiofs_LegacyFailurePropagates ensures the libkrun return code
+// from the legacy krun_add_virtiofs surfaces as an error in the fallback
+// path.
+func TestAddVirtiofs_LegacyFailurePropagates(t *testing.T) {
+	lib := &libkrun{
+		AddVirtiofs: func(ctxID uint32, tag, path string) int32 {
+			return -1
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	err := vmc.AddVirtiofs(context.Background(), "tag", "/p", false)
+	if err == nil {
+		t.Fatalf("expected error when krun_add_virtiofs returns non-zero")
+	}
+}
+
+// TestAddVirtiofs_LibraryNotLoaded verifies the early error when neither
+// virtiofs entry point is bound (i.e. the library failed to load).
+func TestAddVirtiofs_LibraryNotLoaded(t *testing.T) {
+	vmc := &vmcontext{lib: &libkrun{}}
+	if err := vmc.AddVirtiofs(context.Background(), "tag", "/p", false); err == nil {
+		t.Fatalf("expected error when neither AddVirtiofs nor AddVirtiofs3 is bound")
+	}
+}


### PR DESCRIPTION
## Summary

Bind mounts requested as read-only in the OCI spec lost the `ro` flag on the way down to libkrun.
This PR plumbs the flag end-to-end:

- Parse `ro` from `m.Options` in `bindMounter.FromBundle` (mirroring the existing logic already used for `ext4` mounts) and store it on `bindMount`.
- Pass it to `sandbox.WithFS`. The sandbox/vm layer already converts `Filesystem.Readonly` into `vm.WithReadOnly()`, so no change is needed there.
- Apply the `vm.MountOpt` slice in `vmInstance.AddFS` and forward `MountConfig.Readonly` to libkrun.
- Optionally bind `krun_add_virtiofs3` (libkrun >= 1.18) and prefer it when the symbol is present, falling back to `krun_add_virtiofs` with a one-line warning on older libkrun. The FFI loader gains a small `optional` tag handling so missing symbols don't fail the whole load.

