### PR TITLE
pkg/logging: add SetShimLogLevel / GetShimLogLevel for runtime log-level changes

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -31,6 +31,46 @@ import (
 	"github.com/containerd/log"
 )
 
+// shimLogLevel is the slog LevelVar wired into the handler created by
+// SetupShimLog. It defaults to INFO and can be updated at runtime via
+// SetShimLogLevel.
+var shimLogLevel slog.LevelVar
+
+// SetShimLogLevel updates both the slog handler level and the underlying
+// containerd/log (logrus) level so that records routed through either reach
+// the shim's output. Logrus filters before the slog hook fires, so updating
+// only the LevelVar has no effect on log.G(ctx).Debug/... call sites.
+// It is safe to call concurrently and takes effect immediately.
+func SetShimLogLevel(level slog.Level) {
+	shimLogLevel.Set(level)
+	// Also update the containerd/log (logrus) level so that log.G(ctx).Debug/...
+	// calls reach the slog hook. Logrus filters before the hook fires, so the
+	// LevelVar change alone has no effect on logrus-routed call sites.
+	log.SetLevel(slogToLogrusLevelString(level)) //nolint:errcheck
+}
+
+// slogToLogrusLevelString maps a slog.Level to the logrus level string
+// accepted by log.SetLevel.
+func slogToLogrusLevelString(l slog.Level) string {
+	switch {
+	case l < slog.LevelDebug: // trace: containerd/log maps LevelDebug-4 → TraceLevel
+		return "trace"
+	case l < slog.LevelInfo:
+		return "debug"
+	case l < slog.LevelWarn:
+		return "info"
+	case l < slog.LevelError:
+		return "warn"
+	default:
+		return "error"
+	}
+}
+
+// GetShimLogLevel returns the current log level for the shim handler.
+func GetShimLogLevel() slog.Level {
+	return shimLogLevel.Level()
+}
+
 // SetupShimLog configures slog-based logging for the shim process.
 // It opens the platform-specific log output (FIFO on Unix, named pipe
 // on Windows), then creates a slog TextHandler and sets it as the
@@ -42,6 +82,9 @@ import (
 //
 // For the short-lived start and delete actions, only [log.UseSlog] is
 // called to route logrus through slog; the log output is not opened.
+//
+// The package-level [shimLogLevel] variable is used for the handler level
+// so that callers may adjust the level at runtime via [SetShimLogLevel].
 func SetupShimLog() {
 	log.UseSlog()
 
@@ -75,13 +118,12 @@ func SetupShimLog() {
 
 	w := openShimLog(ns, id)
 
-	var level slog.LevelVar
 	if debug {
-		level.Set(slog.LevelDebug)
+		shimLogLevel.Set(slog.LevelDebug)
 		log.SetLevel("debug") //nolint:errcheck
 	}
 
-	handler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: &level}).WithAttrs(attrs)
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: &shimLogLevel}).WithAttrs(attrs)
 	SetBaseHandler(handler)
 	slog.SetDefault(slog.New(handler).With("component", "shim"))
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -23,6 +23,8 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/containerd/log"
 )
 
 // discardHandler is a handler that discards all output but still processes records.
@@ -246,5 +248,85 @@ func TestForwardJSONLog_NoMsg(t *testing.T) {
 	SetBaseHandler(discardHandler{})
 	if forwardJSONLog(`{"level":"INFO","time":"2024-01-01T00:00:00Z"}`) {
 		t.Error("expected false for JSON without msg field")
+	}
+}
+
+// --- ShimLogLevel tests ---
+
+// TestSetGetShimLogLevel_RoundTrip verifies that SetShimLogLevel followed by
+// GetShimLogLevel returns the value that was set, and that the containerd/log
+// (logrus) level is updated in lockstep.
+func TestSetGetShimLogLevel_RoundTrip(t *testing.T) {
+	// Restore the original levels after the test so we don't pollute other tests.
+	orig := shimLogLevel.Level()
+	origLogrus := log.GetLevel().String()
+	t.Cleanup(func() {
+		shimLogLevel.Set(orig)
+		_ = log.SetLevel(origLogrus)
+	})
+
+	cases := []struct {
+		slogLevel    slog.Level
+		logrusLevel  string
+	}{
+		{slog.LevelDebug, "debug"},
+		{slog.LevelInfo, "info"},
+		{slog.LevelWarn, "warning"},
+		{slog.LevelError, "error"},
+	}
+	for _, tc := range cases {
+		SetShimLogLevel(tc.slogLevel)
+		if got := GetShimLogLevel(); got != tc.slogLevel {
+			t.Errorf("SetShimLogLevel(%v): GetShimLogLevel() = %v, want %v", tc.slogLevel, got, tc.slogLevel)
+		}
+		if got := log.GetLevel().String(); got != tc.logrusLevel {
+			t.Errorf("SetShimLogLevel(%v): log.GetLevel() = %q, want %q", tc.slogLevel, got, tc.logrusLevel)
+		}
+	}
+}
+
+// TestShimLogLevel_HandlerRespectsPostSetupChange verifies that a handler
+// wired to the package-level shimLogLevel (as SetupShimLog does) immediately
+// reflects level changes made after setup via SetShimLogLevel.
+func TestShimLogLevel_HandlerRespectsPostSetupChange(t *testing.T) {
+	// Restore global state after the test — shimLogLevel and the logrus level
+	// (SetShimLogLevel updates both).
+	orig := shimLogLevel.Level()
+	origLogrus := log.GetLevel()
+	t.Cleanup(func() {
+		shimLogLevel.Set(orig)
+		_ = log.SetLevel(origLogrus.String())
+	})
+
+	// Start at INFO (the zero value / default).
+	shimLogLevel.Set(slog.LevelInfo)
+
+	// Build the handler exactly as SetupShimLog does: pass &shimLogLevel as the
+	// HandlerOptions.Level. slog.TextHandler.Enabled reads the LevelVar on every
+	// call, so changes via SetShimLogLevel take effect immediately.
+	h := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: &shimLogLevel})
+
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("handler should NOT be enabled for DEBUG at initial INFO level")
+	}
+	if !h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("handler should be enabled for INFO at initial INFO level")
+	}
+
+	// Lower the level to DEBUG via SetShimLogLevel — no handler rebuild needed.
+	SetShimLogLevel(slog.LevelDebug)
+
+	if !h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("handler should be enabled for DEBUG after SetShimLogLevel(Debug)")
+	}
+
+	// Raise the level to WARN.
+	SetShimLogLevel(slog.LevelWarn)
+
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("handler should NOT be enabled for INFO after SetShimLogLevel(Warn)")
+	}
+	if !h.Enabled(context.Background(), slog.LevelWarn) {
+		t.Fatal("handler should be enabled for WARN after SetShimLogLevel(Warn)")
 	}
 }


### PR DESCRIPTION
Hoist the shim's `slog.LevelVar` to package scope so that callers can adjust the log level at runtime without recreating the handler.

- Add package-level `shimLogLevel slog.LevelVar` wired into the handler created by `SetupShimLog`.
- Export `SetShimLogLevel(slog.Level)` to set the level atomically.
- Export `GetShimLogLevel() slog.Level` to read the current level.

Previously the `slog.LevelVar` was local to `SetupShimLog` and unreachable after the function returned, making runtime level changes impossible.