### PR TITLE
vminit: replace initramfs with erofs rootfs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - name: Build remaining artifacts (initrd and shim)
+      - name: Build remaining artifacts (rootfs and shim)
         run: docker buildx bake host-binaries guest-binaries
 
       - name: Add _output to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - name: Build remaining artifacts (initrd and shim)
+      - name: Build remaining artifacts (rootfs and shim)
         run: |
           echo "Building host and guest binaries:"
           docker buildx bake host-binaries guest-binaries
@@ -302,8 +302,8 @@ jobs:
           echo "Kernel:"
           file _output/nerdbox-kernel-${{ matrix.arch }}
           echo ""
-          echo "Initrd:"
-          file _output/nerdbox-initrd
+          echo "Rootfs:"
+          file _output/nerdbox-rootfs.erofs
           echo ""
           echo "Shim:"
           file _output/containerd-shim-nerdbox-v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------------
 # syntax=docker/dockerfile:1
 
-# Build the Linux kernel, initrd ,and containerd shim for running nerbox
+# Build the Linux kernel, erofs rootfs, and containerd shim for running nerdbox
 
 ARG XX_VERSION=1.9.0
 ARG GO_VERSION=1.26.3
@@ -223,31 +223,36 @@ WORKDIR /usr/src/crun
 ARG TARGETARCH
 RUN mkdir /build && wget -O /build/crun https://github.com/containers/crun/releases/download/1.24/crun-1.24-linux-${TARGETARCH}-disable-systemd
 
-FROM base AS initrd-build
-WORKDIR /usr/src/init
+FROM base AS erofs-build
+WORKDIR /usr/src/rootfs
 ARG TARGETPLATFORM
-RUN --mount=type=cache,sharing=locked,id=initrd-aptlib,target=/var/lib/apt \
-    --mount=type=cache,sharing=locked,id=initrd-aptcache,target=/var/cache/apt \
-        apt-get update && apt-get install -y --no-install-recommends cpio
+RUN --mount=type=cache,sharing=locked,id=erofs-aptlib,target=/var/lib/apt \
+    --mount=type=cache,sharing=locked,id=erofs-aptcache,target=/var/cache/apt \
+        apt-get update && apt-get install -y --no-install-recommends erofs-utils
 
-RUN mkdir sbin proc sys tmp run
+# Create all mount-point directories required by vminitd's systemMounts.
+# /etc is included so that a tmpfs can be mounted over it at runtime,
+# making it writable even though the erofs image itself is read-only.
+# /var/run is a symlink to /run so that crun state writes land on the
+# writable /run tmpfs rather than failing against the read-only rootfs.
+RUN mkdir -p dev etc proc run sbin sys tmp var && ln -s /run var/run
 
-COPY --from=vminit-build /build/vminitd ./init
+COPY --from=vminit-build /build/vminitd ./sbin/vminitd
 COPY --from=crun-build /build/crun ./sbin/crun
 
 RUN <<EOT
     set -e
-    chmod +x sbin/crun
+    chmod +x sbin/vminitd sbin/crun
     mkdir /build
-    (find . -print0 | cpio --null -H newc -o ) | gzip -9 > /build/nerdbox-initrd
+    mkfs.erofs -zlz4 /build/nerdbox-rootfs.erofs .
 EOT
 
 FROM scratch AS kernel
 ARG KERNEL_ARCH="x86_64"
 COPY --from=kernel-build /build/kernel /nerdbox-kernel-${KERNEL_ARCH}
 
-FROM scratch AS initrd
-COPY --from=initrd-build /build/nerdbox-initrd /nerdbox-initrd
+FROM scratch AS erofs
+COPY --from=erofs-build /build/nerdbox-rootfs.erofs /nerdbox-rootfs.erofs
 
 FROM scratch AS shim
 COPY --from=shim-build /build/containerd-shim-nerdbox-v1 /containerd-shim-nerdbox-v1

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ _output/vminitd: cmd/vminitd FORCE
 	@echo "$(WHALE) $@"
 	$(GO) build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_STATIC_LDFLAGS} ${GO_STATIC_TAGS}  ./$<
 
-_output/nerdbox-initrd: cmd/vminitd FORCE
-	@task build:initrd
+_output/nerdbox-rootfs.erofs: cmd/vminitd FORCE
+	@task build:rootfs
 
 _output/integration.test: integration FORCE
 	@task build:integration

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The results will be in the `_output` directory.
 > On macOS, use these commands:
 > ```bash
 > make KERNEL_ARCH=arm64 KERNEL_NPROC=12
-> make _output/containerd-shim-nerdbox-v1 _output/nerdbox-initrd
+> make _output/containerd-shim-nerdbox-v1 _output/nerdbox-rootfs.erofs
 > ```
 
 ### Configuring containerd

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,14 +31,14 @@ tasks:
         platforms: [darwin]
 
   build:guest:
-    desc: Build guest artifacts (kernel and initrd) via Docker Buildx Bake
+    desc: Build guest artifacts (kernel and rootfs) via Docker Buildx Bake
     cmds:
-      - KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake kernel initrd
+      - KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake kernel rootfs
 
-  build:initrd:
-    desc: Build the nerdbox initrd via Docker Buildx Bake
+  build:rootfs:
+    desc: Build the nerdbox erofs rootfs via Docker Buildx Bake
     cmds:
-      - KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake initrd
+      - KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake rootfs
 
   build:integration:
     desc: Build the integration test binary

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -86,7 +86,7 @@ group "host-binaries" {
 }
 
 group "guest-binaries" {
-  targets = ["initrd"]
+  targets = ["rootfs"]
 }
 
 target "menuconfig" {
@@ -101,9 +101,9 @@ target "kernel" {
   output = ["${DESTDIR}"]
 }
 
-target "initrd" {
+target "rootfs" {
   inherits = ["_guest_common"]
-  target = "initrd"
+  target = "erofs"
   output = ["${DESTDIR}"]
 }
 

--- a/internal/shim/sandbox/sandbox.go
+++ b/internal/shim/sandbox/sandbox.go
@@ -32,6 +32,12 @@ type Sandbox interface {
 	Stop(context.Context) error
 	Client() (*ttrpc.Client, error)
 	StartStream(context.Context, string) (net.Conn, error)
+
+	// ReservedDisks returns the number of virtio-block devices that the
+	// underlying VM implementation pre-attaches before any
+	// container-supplied disks. The disk allocator uses this value to
+	// start container disk letters after the reserved range.
+	ReservedDisks() int
 }
 
 type Filesystem struct {

--- a/internal/shim/sandbox/vm/vm.go
+++ b/internal/shim/sandbox/vm/vm.go
@@ -41,6 +41,19 @@ type localsandbox struct {
 	instance vm.Instance
 }
 
+// diskReserver is a package-private optional interface for vm.Manager
+// implementations that pre-attach virtio-block devices before container disks.
+type diskReserver interface {
+	ReservedDisks() int
+}
+
+func (s *localsandbox) ReservedDisks() int {
+	if dr, ok := s.vmm.(diskReserver); ok {
+		return dr.ReservedDisks()
+	}
+	return 0
+}
+
 func (s *localsandbox) Start(ctx context.Context, opts ...sandbox.Opt) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -41,22 +41,33 @@ import (
 // mounts (those carrying device= options) are not affected: they continue
 // to use the existing flat-concat VMDK path inline.
 //
-// Packing into a GPT VMDK reduces virtio-block consumption (which is capped
-// at 25 letters per VM) and lets the shim handle deep stacks of independent
-// erofs mounts without coordinating layer offsets in the snapshotter.
+// Packing into a GPT VMDK reduces virtio-block consumption (vda–vdz = 26
+// devices total, some of which are reserved by the VM implementation) and
+// lets the shim handle deep stacks of independent erofs mounts without
+// coordinating layer offsets in the snapshotter.
 const gptLayerThreshold = 8
 
-// diskAllocator assigns sequential virtio disk letters (vda, vdb, …).
+// diskAllocator assigns sequential virtio disk letters starting after any
+// disks reserved by the VM implementation (see vm.Manager.ReservedDisks).
 // A single instance is shared across rootfs and volume disk allocation so
 // that all disks within a container get unique, collision-free letters.
-type diskAllocator struct{ next byte }
+type diskAllocator struct {
+	start byte // first letter available for container disks
+	next  byte // next letter to assign
+}
 
-func newDiskAllocator() diskAllocator { return diskAllocator{next: 'a'} }
+// newDiskAllocator returns a diskAllocator whose first letter is
+// 'a'+reserved, skipping the virtio-block devices the VM implementation
+// pre-attaches before any container disks.
+func newDiskAllocator(reserved int) diskAllocator {
+	first := byte('a') + byte(reserved)
+	return diskAllocator{start: first, next: first}
+}
 
 func (d *diskAllocator) Next() byte { c := d.next; d.next++; return c }
 
-// count returns the total number of disks allocated so far.
-func (d *diskAllocator) count() int { return int(d.next - 'a') }
+// count returns the number of container disks allocated so far.
+func (d *diskAllocator) count() int { return int(d.next - d.start) }
 
 type diskOptions struct {
 	name     string
@@ -351,7 +362,7 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 
 		hash := sha256.Sum256([]byte(m.Destination))
 		tag := fmt.Sprintf("bind-%x", hash[:8])
-		vmTarget := "/mnt/" + tag
+		vmTarget := "/run/mnt/" + tag
 
 		// For files, share the parent directory via virtiofs since virtiofs
 		// operates on directories. The spec source points to the file within
@@ -425,7 +436,7 @@ type blockMounter struct {
 
 // FromBundle iterates the OCI spec mounts and for each ext4 mount:
 //   - allocates a virtio-block disk letter via the shared diskAllocator
-//   - rewrites the spec source to /mnt/sdX (where vminitd will mount it)
+//   - rewrites the spec source to /run/mnt/sdX (where vminitd will mount it)
 //   - records a sandbox.WithDisk opt for the host image path
 //   - records a -blockmount init arg so vminitd mounts the device at startup
 func (bm *blockMounter) FromBundle(ctx context.Context, b *bundle.Bundle, id string, da *diskAllocator) error {
@@ -443,7 +454,7 @@ func (bm *blockMounter) FromBundle(ctx context.Context, b *bundle.Bundle, id str
 		}
 
 		device := fmt.Sprintf("/dev/vd%c", letter)
-		vmTarget := fmt.Sprintf("/mnt/sd%c", letter)
+		vmTarget := fmt.Sprintf("/run/mnt/sd%c", letter)
 
 		hostSrc := b.Spec.Mounts[i].Source
 		b.Spec.Mounts[i].Type = "bind"

--- a/internal/shim/task/mount_test.go
+++ b/internal/shim/task/mount_test.go
@@ -80,10 +80,10 @@ func TestBlockMountsProvider(t *testing.T) {
 				{BlockID: "disk-97-cid", MountPath: "/vol/myvolume.img", Flags: 0},
 			},
 			wantSpecMounts: []specs.Mount{
-				{Type: "bind", Source: "/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
+				{Type: "bind", Source: "/run/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "ext4", Source: "/dev/vda", Target: "/mnt/sda"},
+				{Type: "ext4", Source: "/dev/vda", Target: "/run/mnt/sda"},
 			},
 		},
 		{
@@ -95,10 +95,10 @@ func TestBlockMountsProvider(t *testing.T) {
 				{BlockID: "disk-97-cid", MountPath: "/vol/myvolume.img", Flags: sandbox.DiskFlagReadonly},
 			},
 			wantSpecMounts: []specs.Mount{
-				{Type: "bind", Source: "/mnt/sda", Destination: "/data", Options: []string{"rbind", "ro"}},
+				{Type: "bind", Source: "/run/mnt/sda", Destination: "/data", Options: []string{"rbind", "ro"}},
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "ext4", Source: "/dev/vda", Target: "/mnt/sda", Options: []string{"ro"}},
+				{Type: "ext4", Source: "/dev/vda", Target: "/run/mnt/sda", Options: []string{"ro"}},
 			},
 		},
 		{
@@ -112,12 +112,12 @@ func TestBlockMountsProvider(t *testing.T) {
 				{BlockID: "disk-98-cid", MountPath: "/vol/vol2.img", Flags: sandbox.DiskFlagReadonly},
 			},
 			wantSpecMounts: []specs.Mount{
-				{Type: "bind", Source: "/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
-				{Type: "bind", Source: "/mnt/sdb", Destination: "/logs", Options: []string{"rbind", "ro"}},
+				{Type: "bind", Source: "/run/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
+				{Type: "bind", Source: "/run/mnt/sdb", Destination: "/logs", Options: []string{"rbind", "ro"}},
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "ext4", Source: "/dev/vda", Target: "/mnt/sda"},
-				{Type: "ext4", Source: "/dev/vdb", Target: "/mnt/sdb", Options: []string{"ro"}},
+				{Type: "ext4", Source: "/dev/vda", Target: "/run/mnt/sda"},
+				{Type: "ext4", Source: "/dev/vdb", Target: "/run/mnt/sdb", Options: []string{"ro"}},
 			},
 		},
 		{
@@ -132,11 +132,11 @@ func TestBlockMountsProvider(t *testing.T) {
 			},
 			wantSpecMounts: []specs.Mount{
 				{Type: "tmpfs", Source: "tmpfs", Destination: "/tmp"},
-				{Type: "bind", Source: "/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
+				{Type: "bind", Source: "/run/mnt/sda", Destination: "/data", Options: []string{"rbind"}},
 				{Type: "proc", Source: "proc", Destination: "/proc"},
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "ext4", Source: "/dev/vda", Target: "/mnt/sda"},
+				{Type: "ext4", Source: "/dev/vda", Target: "/run/mnt/sda"},
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestBlockMountsProvider(t *testing.T) {
 				Spec: specs.Spec{Mounts: tc.mounts},
 			}
 
-			da := newDiskAllocator()
+			da := newDiskAllocator(0)
 			bm := &blockMounter{}
 			err := bm.FromBundle(context.Background(), b, id, &da)
 			assert.NoError(t, err)
@@ -209,12 +209,12 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantSpecSources: []string{"/run/mnt/bind-8c5eaa445dd84f17"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
@@ -229,13 +229,13 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 					readOnly: true,
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantSpecSources: []string{"/run/mnt/bind-8c5eaa445dd84f17"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: true},
@@ -250,13 +250,13 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-6dace5108a719565",
 					hostSrc:  tmpDir,
-					vmTarget: "/mnt/bind-6dace5108a719565",
+					vmTarget: "/run/mnt/bind-6dace5108a719565",
 					readOnly: true,
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
+			wantSpecSources: []string{"/run/mnt/bind-6dace5108a719565/testfile.txt"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/run/mnt/bind-6dace5108a719565"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: true},
@@ -272,22 +272,22 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 				},
 				{
 					tag:      "bind-529984c9ac58b7ec",
 					hostSrc:  testdirConfig,
-					vmTarget: "/mnt/bind-529984c9ac58b7ec",
+					vmTarget: "/run/mnt/bind-529984c9ac58b7ec",
 					readOnly: true,
 				},
 			},
 			wantSpecSources: []string{
-				"/mnt/bind-8c5eaa445dd84f17",
-				"/mnt/bind-529984c9ac58b7ec",
+				"/run/mnt/bind-8c5eaa445dd84f17",
+				"/run/mnt/bind-529984c9ac58b7ec",
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
-				{Type: "virtiofs", Source: "bind-529984c9ac58b7ec", Target: "/mnt/bind-529984c9ac58b7ec"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-529984c9ac58b7ec", Target: "/run/mnt/bind-529984c9ac58b7ec"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
@@ -305,16 +305,16 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 				},
 			},
 			wantSpecSources: []string{
 				"tmpfs",
-				"/mnt/bind-8c5eaa445dd84f17",
+				"/run/mnt/bind-8c5eaa445dd84f17",
 				"proc",
 			},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
@@ -329,12 +329,12 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-6dace5108a719565",
 					hostSrc:  tmpDir,
-					vmTarget: "/mnt/bind-6dace5108a719565",
+					vmTarget: "/run/mnt/bind-6dace5108a719565",
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
+			wantSpecSources: []string{"/run/mnt/bind-6dace5108a719565/testfile.txt"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/run/mnt/bind-6dace5108a719565"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: false},
@@ -351,12 +351,12 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantSpecSources: []string{"/run/mnt/bind-8c5eaa445dd84f17"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
@@ -372,13 +372,13 @@ func TestBindMountsProvider(t *testing.T) {
 				{
 					tag:      "bind-8c5eaa445dd84f17",
 					hostSrc:  testdirData,
-					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					vmTarget: "/run/mnt/bind-8c5eaa445dd84f17",
 					readOnly: true,
 				},
 			},
-			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantSpecSources: []string{"/run/mnt/bind-8c5eaa445dd84f17"},
 			wantVmMounts: []mount.Mount{
-				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/run/mnt/bind-8c5eaa445dd84f17"},
 			},
 			wantFS: []sandbox.Filesystem{
 				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: true},
@@ -452,7 +452,7 @@ func TestTransformMountsErofs(t *testing.T) {
 			Options: []string{"ro"},
 		}}
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		out, opts, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -493,7 +493,7 @@ func TestTransformMountsErofs(t *testing.T) {
 			Options: append([]string{"ro"}, deviceOpts...),
 		}}
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		out, opts, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -538,7 +538,7 @@ func TestTransformMountsErofs(t *testing.T) {
 			})
 		}
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		out, opts, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -577,7 +577,7 @@ func TestTransformMountsErofs(t *testing.T) {
 			})
 		}
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		out, opts, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -648,7 +648,7 @@ func TestTransformMountsErofs(t *testing.T) {
 		ms = append(ms, multiDevice)
 		ms = append(ms, plainMounts[2:]...)
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		out, opts, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -694,7 +694,7 @@ func TestTransformMountsErofs(t *testing.T) {
 			})
 		}
 
-		da := newDiskAllocator()
+		da := newDiskAllocator(0)
 		_, _, err := transformMounts(context.Background(), id, ms, &da, bundleDir)
 		require.NoError(t, err)
 
@@ -703,7 +703,7 @@ func TestTransformMountsErofs(t *testing.T) {
 		fi1, err := os.Stat(gptPath)
 		require.NoError(t, err)
 
-		da2 := newDiskAllocator()
+		da2 := newDiskAllocator(0)
 		_, _, err = transformMounts(context.Background(), id, ms, &da2, bundleDir)
 		require.NoError(t, err)
 

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -260,21 +260,27 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 
 	// da is shared across rootfs and volume disk allocation so that all
 	// virtio-block devices within a container get unique, sequential letters.
-	da := newDiskAllocator()
+	// Start after the disks the VM implementation reserves for its own use
+	// (e.g. the erofs rootfs at /dev/vda in the libkrun backend).
+	reservedDisks := s.sb.ReservedDisks()
+	da := newDiskAllocator(reservedDisks)
 	m, mountOpts, err := setupMounts(ctx, r.ID, r.Rootfs, b.Rootfs, filepath.Join(r.Bundle, "mounts"), &da, r.Bundle)
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
 
 	// Process ext4 volume mounts in the OCI spec after rootfs disks have been
-	// allocated, so that rootfs always gets vda/vdb and volumes get vdc+.
+	// allocated, so that rootfs disks always precede volume disks.
 	var blockM blockMounter
 	if err := blockM.FromBundle(ctx, b, r.ID, &da); err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
 
-	if da.count() > 25 {
-		return nil, errgrpc.ToGRPCf(errdefs.ErrNotImplemented, "exceeded maximum virtio disk count: %d > 25", da.count())
+	// Enforce the virtio-block letter limit (vda–vdz = 26 devices total).
+	// count() reflects only container disks; add the reserved range to get
+	// the true total and compare against the full alphabet.
+	if total := reservedDisks + da.count(); total > 26 {
+		return nil, errgrpc.ToGRPCf(errdefs.ErrNotImplemented, "exceeded maximum virtio disk count: %d > 26", total)
 	}
 
 	var opts []sandbox.Opt

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -56,6 +56,11 @@ func NewManager() vm.Manager {
 
 type vmManager struct{}
 
+// ReservedDisks returns 1 because the libkrun shim always attaches the
+// erofs rootfs image as the first virtio-blk device (/dev/vda) in
+// NewInstance, before any container-supplied disks are added.
+func (*vmManager) ReservedDisks() int { return 1 }
+
 func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, error) {
 	// On Linux, libkrun panics if KVM is not available, so check it here.
 	if err := kvm.CheckKVM(); err != nil {
@@ -67,7 +72,7 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 		p2         = filepath.SplitList(os.Getenv("LIBKRUN_PATH"))
 		krunPath   string
 		kernelPath string
-		initrdPath string
+		rootfsPath string
 	)
 	if runtime.GOOS != "windows" && len(p2) == 0 {
 		p2 = []string{"/usr/local/lib", "/usr/local/lib64", "/usr/lib", "/lib"}
@@ -103,11 +108,11 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 				kernelPath = path
 			}
 		}
-		if initrdPath == "" {
-			for _, name := range []string{fmt.Sprintf("nerdbox-initrd-%s", arch), "nerdbox-initrd"} {
+		if rootfsPath == "" {
+			for _, name := range []string{fmt.Sprintf("nerdbox-rootfs-%s.erofs", arch), "nerdbox-rootfs.erofs"} {
 				path = filepath.Join(dir, name)
 				if _, err := os.Stat(path); err == nil {
-					initrdPath = path
+					rootfsPath = path
 					break
 				}
 			}
@@ -119,8 +124,8 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 	if kernelPath == "" {
 		return nil, fmt.Errorf("nerdbox-kernel not found in PATH or LIBKRUN_PATH")
 	}
-	if initrdPath == "" {
-		return nil, fmt.Errorf("nerdbox-initrd-%s or nerdbox-initrd not found in PATH or LIBKRUN_PATH", arch)
+	if rootfsPath == "" {
+		return nil, fmt.Errorf("nerdbox-rootfs-%s.erofs or nerdbox-rootfs.erofs not found in PATH or LIBKRUN_PATH", arch)
 	}
 
 	lib, handler, err := openLibkrun(krunPath)
@@ -141,11 +146,19 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 		return nil, err
 	}
 
+	// Add the erofs rootfs as the first virtio-blk device so that it is
+	// always exposed as /dev/vda inside the guest.  Container image disks
+	// are added later via AddDisk, which appends to the device list, so
+	// they receive /dev/vdb, /dev/vdc, … in order of addition.
+	if err := vmc.AddDisk2("vmrootfs", rootfsPath, 0, true); err != nil {
+		return nil, fmt.Errorf("failed to add VM rootfs disk %q: %w", rootfsPath, err)
+	}
+
 	return &vmInstance{
 		vmc:        vmc,
 		state:      state,
 		kernelPath: kernelPath,
-		initrdPath: initrdPath,
+		rootfsPath: rootfsPath,
 		streamPath: filepath.Join(state, "streaming.sock"),
 		lib:        lib,
 		handler:    handler,
@@ -158,7 +171,7 @@ type vmInstance struct {
 	state string
 
 	kernelPath string
-	initrdPath string
+	rootfsPath string
 	streamPath string
 
 	lib     *libkrun
@@ -241,7 +254,11 @@ func (v *vmInstance) Start(ctx context.Context, opts ...vm.StartOpt) (err error)
 		return errors.New("VM instance already started")
 	}
 
-	if err := v.vmc.SetKernel(v.kernelPath, v.initrdPath, "console=hvc0"); err != nil {
+	// Boot directly from the erofs rootfs block device (/dev/vda).
+	// No initrd is needed: the kernel mounts the erofs image as the
+	// root filesystem and launches vminitd directly as PID 1.
+	const kernelCmdline = "console=hvc0 root=/dev/vda rootfstype=erofs ro init=/sbin/vminitd"
+	if err := v.vmc.SetKernel(v.kernelPath, "", kernelCmdline); err != nil {
 		return fmt.Errorf("failed to set kernel: %w", err)
 	}
 

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -92,7 +92,11 @@ func (vmc *vmcontext) SetKernel(kernelPath string, initrdPath string, kernelCmdl
 	} else {
 		format = kernelFormatElf
 	}
-	ret := vmc.lib.SetKernel(vmc.ctxID, kernelPath, format, initrdPath, kernelCmdline)
+	// cString returns nil for an empty string, which libkrun interprets as
+	// "no initramfs".  Passing an empty Go string directly via purego would
+	// produce a non-null pointer to an empty C string, causing libkrun to
+	// try (and fail) to open a file at path "".
+	ret := vmc.lib.SetKernel(vmc.ctxID, kernelPath, format, vmc.cString(initrdPath), kernelCmdline)
 	if ret != 0 {
 		return fmt.Errorf("krun_set_kernel failed: %d", ret)
 	}
@@ -250,16 +254,16 @@ func (vmc *vmcontext) cStringArray(a []string) unsafe.Pointer {
 }
 
 type libkrun struct {
-	SetLogLevel      func(level uint32) int32                                                               `C:"krun_set_log_level"`
-	InitLog          func(fd uintptr, level uint32, style uint32, options uint32) int32                     `C:"krun_init_log"`
-	CreateCtx        func() int32                                                                           `C:"krun_create_ctx"`
-	FreeCtx          func(ctxID uint32) int32                                                               `C:"krun_free_ctx"`
-	SetVMConfig      func(ctxID uint32, cpu uint8, ram uint32) int32                                        `C:"krun_set_vm_config"`
-	SetKernel        func(ctxID uint32, path string, format uint32, initramfs string, cmdline string) int32 `C:"krun_set_kernel"`
-	SetExec          func(ctxID uint32, path string, args unsafe.Pointer, env unsafe.Pointer) int32         `C:"krun_set_exec"`
-	SetConsoleOutput func(ctxID uint32, path string) int32                                                  `C:"krun_set_console_output"`
-	StartEnter       func(ctxID uint32) int32                                                               `C:"krun_start_enter"`
-	AddVsockPort     func(ctxID, port uint32, path string, listen bool) int32                               `C:"krun_add_vsock_port2"`
+	SetLogLevel      func(level uint32) int32                                                                       `C:"krun_set_log_level"`
+	InitLog          func(fd uintptr, level uint32, style uint32, options uint32) int32                             `C:"krun_init_log"`
+	CreateCtx        func() int32                                                                                   `C:"krun_create_ctx"`
+	FreeCtx          func(ctxID uint32) int32                                                                       `C:"krun_free_ctx"`
+	SetVMConfig      func(ctxID uint32, cpu uint8, ram uint32) int32                                                `C:"krun_set_vm_config"`
+	SetKernel        func(ctxID uint32, path string, format uint32, initramfs unsafe.Pointer, cmdline string) int32 `C:"krun_set_kernel"`
+	SetExec          func(ctxID uint32, path string, args unsafe.Pointer, env unsafe.Pointer) int32                 `C:"krun_set_exec"`
+	SetConsoleOutput func(ctxID uint32, path string) int32                                                          `C:"krun_set_console_output"`
+	StartEnter       func(ctxID uint32) int32                                                                       `C:"krun_start_enter"`
+	AddVsockPort     func(ctxID, port uint32, path string, listen bool) int32                                       `C:"krun_add_vsock_port2"`
 	// AddVirtiofs3 forwards a virtio-fs share with explicit flags. shmSize
 	// requests a DAX window size in bytes for the share; 0 means "use the
 	// libkrun default" (which is what every call site here passes). Plumb a

--- a/internal/vminit/process/init.go
+++ b/internal/vminit/process/init.go
@@ -138,10 +138,8 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) (retError error) {
 	}
 
 	opts := &runc.CreateOpts{
-		PidFile: pidFile.Path(),
-		// Pivot root is returning invalid argument
-		// Could otherwise use p.NoPivotRoot
-		NoPivot:      true,
+		PidFile:      pidFile.Path(),
+		NoPivot:      p.NoPivotRoot,
 		NoNewKeyring: p.NoNewKeyring,
 	}
 	if p.io != nil {

--- a/pkg/vminit/initd/initd.go
+++ b/pkg/vminit/initd/initd.go
@@ -136,18 +136,10 @@ func Run(ctx context.Context) error {
 
 	ctx, shutdownSvc := shutdown.WithShutdown(ctx)
 
-	dhcpRenewer, err := systemInit(ctx, config, shutdownSvc)
-	if err != nil {
+	if err := systemInit(ctx, config, shutdownSvc); err != nil {
 		runErr = err
 		return err
 	}
-
-	go func() {
-		if err := dhcpRenewer(ctx); err != nil {
-			log.G(ctx).WithError(err).Error("failed to renew DHCP leases")
-			shutdownSvc.Shutdown()
-		}
-	}()
 
 	if config.DumpInfo {
 		systools.DumpInfo(ctx)
@@ -199,29 +191,35 @@ func Run(ctx context.Context) error {
 	}
 }
 
-func systemInit(ctx context.Context, config Config, shutdownSvc shutdown.Service) (func(context.Context) error, error) {
+func systemInit(ctx context.Context, config Config, shutdownSvc shutdown.Service) error {
+	t := time.Now()
+
 	if err := systemMounts(); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := setupCgroupControl(); err != nil {
-		return nil, err
-	}
-
-	if err := os.Mkdir("/etc", 0755); err != nil && !os.IsExist(err) {
-		return nil, fmt.Errorf("failed to create /etc: %w", err)
+		return err
 	}
 
 	dhcpRenewer, dhcpReleaser, err := vmnetworking.SetupVM(ctx, config.Networks, config.Debug)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	shutdownSvc.RegisterCallback(func(ctx context.Context) error {
 		return dhcpReleaser()
 	})
 
-	return dhcpRenewer, nil
+	go func() {
+		if err := dhcpRenewer(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("failed to renew DHCP leases")
+			shutdownSvc.Shutdown()
+		}
+	}()
+
+	log.G(ctx).WithField("elapsed", time.Since(t)).Info("system init completed")
+	return nil
 }
 
 func systemMounts() error {
@@ -251,16 +249,22 @@ func systemMounts() error {
 		},
 		{
 			Type:    "tmpfs",
-			Source:  "tmpsfs",
+			Source:  "tmpfs",
 			Target:  "/tmp",
 			Options: []string{"nosuid", "noexec", "nodev"},
 		},
+		// Mount a tmpfs over /etc so that runtime writes (resolv.conf,
+		// hosts, etc.) succeed even though the erofs rootfs is read-only.
+		// The /etc directory is pre-created in the erofs image as a mount
+		// point.
 		{
-			Type:    "devtmpfs",
-			Source:  "devtmpsfs",
-			Target:  "/dev",
-			Options: []string{"nosuid", "noexec"},
+			Type:    "tmpfs",
+			Source:  "tmpfs",
+			Target:  "/etc",
+			Options: []string{"nosuid", "noexec", "nodev", "mode=755"},
 		},
+		// /dev is handled by the kernel via CONFIG_DEVTMPFS_MOUNT=y before
+		// the init process starts; no explicit mount is needed here.
 	}, "/")
 }
 

--- a/plugins/shim/streaming/plugin_test.go
+++ b/plugins/shim/streaming/plugin_test.go
@@ -134,6 +134,7 @@ type fakeSandbox struct {
 func (s *fakeSandbox) Start(context.Context, ...sandbox.Opt) error { return errdefs.ErrNotImplemented }
 func (s *fakeSandbox) Stop(context.Context) error                  { return errdefs.ErrNotImplemented }
 func (s *fakeSandbox) Client() (*ttrpc.Client, error)              { return nil, errdefs.ErrNotImplemented }
+func (s *fakeSandbox) ReservedDisks() int                          { return 0 }
 func (s *fakeSandbox) StartStream(context.Context, string) (net.Conn, error) {
 	return s.conn, nil
 }
@@ -333,6 +334,7 @@ type fakeMultiSandbox struct {
 	conns map[string]net.Conn
 }
 
+func (s *fakeMultiSandbox) ReservedDisks() int { return 0 }
 func (s *fakeMultiSandbox) Start(context.Context, ...sandbox.Opt) error {
 	return errdefs.ErrNotImplemented
 }

--- a/test/shim/shim_test.go
+++ b/test/shim/shim_test.go
@@ -54,7 +54,7 @@ func shimBinaryPath() string {
 
 // shimConfig returns the shimtest Config for nerdbox. The PATH passed to
 // the shim process is extended with candidate _output directories so that
-// co-located binaries (nerdbox-kernel-*, nerdbox-initrd, libkrun.so) are
+// co-located binaries (nerdbox-kernel-*, nerdbox-rootfs.erofs, libkrun.so) are
 // found without callers needing to configure anything.
 func shimConfig() shimtest.Config {
 	return shimtest.Config{

--- a/test/stress/stress_test.go
+++ b/test/stress/stress_test.go
@@ -55,7 +55,7 @@ func shimBinaryPath() string {
 
 // shimConfig returns the shimtest Config for nerdbox. The PATH passed to
 // the shim process is extended with candidate _output directories so that
-// co-located binaries (nerdbox-kernel-*, nerdbox-initrd, libkrun.so) are
+// co-located binaries (nerdbox-kernel-*, nerdbox-rootfs.erofs, libkrun.so) are
 // found without callers needing to configure anything.
 func shimConfig() shimtest.Config {
 	return shimtest.Config{


### PR DESCRIPTION
Replace the gzip-compressed CPIO initramfs with an EROFS block device image as the VM root filesystem, eliminating the tmpfs switch_root that was required to make pivot_root available to containers.

The kernel boots directly into the erofs image on /dev/vda via 'root=/dev/vda rootfstype=erofs ro init=/sbin/vminitd', removing the initramfs decompression which contributed significantly to kernel boot time.

Build changes:
- Dockerfile: replace cpio/gzip initrd-build stage with erofs-build stage using mkfs.erofs -zlz4; vminitd placed at /sbin/vminitd
- docker-bake.hcl, Makefile: rename initrd target to rootfs

Host shim changes:
- instance.go: search for nerdbox-rootfs.erofs; add it as the first virtio-blk device in NewInstance so it is always /dev/vda; pass the erofs boot cmdline to krun_set_kernel with no initrd
- krun.go: change SetKernel's initramfs parameter to unsafe.Pointer so that an empty string maps to a C null pointer (purego converts an empty Go string to a non-null pointer, causing libkrun to fail)
- mount.go: start diskAllocator at 'b' since /dev/vda is now the VM rootfs; container disks begin at /dev/vdb

Guest init changes:
- initd.go: replace with systemMounts that mounts proc, sysfs, cgroup2, run, tmp, and a tmpfs over /etc (so runtime writes such as resolv.conf succeed on the read-only erofs). /dev is omitted — CONFIG_DEVTMPFS_MOUNT=y mounts devtmpfs before init starts, and a redundant mount returns EBUSY on the block-device root.