### PR TITLE
vminit: pre-reqs for a read-only erofs rootfs mounted via virtio-pmem

### DIFF
--- a/pkg/vminit/initd/initd.go
+++ b/pkg/vminit/initd/initd.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/mount"
@@ -225,7 +226,7 @@ func systemInit(ctx context.Context, config Config, shutdownSvc shutdown.Service
 }
 
 func systemMounts() error {
-	return mount.All([]mount.Mount{
+	if err := mount.All([]mount.Mount{
 		{
 			Type:    "proc",
 			Source:  "proc",
@@ -256,12 +257,32 @@ func systemMounts() error {
 			Options: []string{"nosuid", "noexec", "nodev"},
 		},
 		{
-			Type:    "devtmpfs",
-			Source:  "devtmpsfs",
-			Target:  "/dev",
-			Options: []string{"nosuid", "noexec"},
+			Type:    "tmpfs",
+			Source:  "tmpfs",
+			Target:  "/etc",
+			Options: []string{"nosuid", "noexec", "nodev"},
 		},
-	}, "/")
+		{
+			Type:    "tmpfs",
+			Source:  "tmpfs",
+			Target:  "/mnt",
+			Options: []string{"nosuid", "nodev"},
+		},
+	}, "/"); err != nil {
+		return err
+	}
+	devMount := mount.Mount{
+		Type:    "devtmpfs",
+		Source:  "devtmpsfs",
+		Target:  "/dev",
+		Options: []string{"nosuid", "noexec"},
+	}
+	if err := devMount.Mount("/"); err != nil && !errors.Is(err, syscall.EBUSY) {
+		// can happen if the kernel auto-mounts devtmpfs before running init
+		return fmt.Errorf("mount source: %q, target: %q, fstype: devtmpfs, flags: 10, data: %q, err: %w",
+			devMount.Source, devMount.Target, "", err)
+	}
+	return nil
 }
 
 func setupCgroupControl() error {


### PR DESCRIPTION
I'm experimenting with switching to a read-only erofs rootfs. I hit 2 issues:

1. Handle EBUSY on the devtmpfs /dev mount.

   With a real rootfs and CONFIG_DEVTMPFS_MOUNT=y, the kernel auto-mounts devtmpfs at /dev before running init, so vminitd's own mount attempt returns EBUSY. Treat EBUSY as success — the devices are already present.

   With a cpio initramfs (tmpfs rootfs) /dev was never in the archive so the kernel couldn't auto-mount there and this path always did a fresh mount. The EBUSY check is a no-op in that case.

2. Add tmpfs mounts for /etc and /mnt.

   An erofs rootfs is read-only. vminitd writes resolv.conf to /etc and the container shim creates bind-mount target directories under /mnt. Mounting a tmpfs over each provides the writable scratch space they need. On a writable rootfs (tmpfs initramfs) these mounts are equivalent to what was already there.