### PR TITLE
Update libkrun build to use nerdbox variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -264,6 +264,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM "${RUST_IMAGE}" AS libkrun-build
 ARG LIBKRUN_VERSION=v1.19.0
+ARG KERNEL_ARCH="x86_64"
 # Pin to the commit that fixes get_extent_at binary search at extent
 # boundaries (merged into imago main as 1907e11b).  A [patch.crates-io]
 # git override substitutes by crate name regardless of version, so this
@@ -281,14 +282,17 @@ RUN git clone --depth 1 --branch ${LIBKRUN_VERSION} https://github.com/container
     printf '\n[patch.crates-io]\nimago = { git = "https://gitlab.com/hreitz/imago.git", rev = "%s" }\n' \
         "${IMAGO_FIX_REV}" >> Cargo.toml && \
     cargo update imago && \
-    make -j$(nproc) BLK=1 NET=1
+    make -j$(nproc) BLK=1 NET=1 && \
+    cp /libkrun/target/release/libkrun.so /libkrun/target/release/libkrun-nerdbox-${KERNEL_ARCH}.so
 
 FROM scratch AS libkrun
-COPY --from=libkrun-build /libkrun/target/release/libkrun.so /libkrun.so
+ARG KERNEL_ARCH="x86_64"
+COPY --from=libkrun-build /libkrun/target/release/libkrun-nerdbox-${KERNEL_ARCH}.so /libkrun-nerdbox-${KERNEL_ARCH}.so
 
 FROM ${GOLANG_IMAGE} AS dev
 ARG CONTAINERD_VERSION=2.1.4
 ARG TARGETARCH
+ARG KERNEL_ARCH="x86_64"
 
 ENV PATH=/go/src/github.com/containerd/nerdbox/_output:$PATH
 WORKDIR /go/src/github.com/containerd/nerdbox
@@ -306,7 +310,7 @@ COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/
 
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 
-COPY --from=libkrun /libkrun.so /usr/local/lib64/libkrun.so
+COPY --from=libkrun /libkrun-nerdbox-${KERNEL_ARCH}.so /usr/local/lib64/libkrun-nerdbox-${KERNEL_ARCH}.so
 ENV LIBKRUN_PATH=/go/src/github.com/containerd/nerdbox/_output
 
 VOLUME /var/lib/containerd

--- a/Dockerfile
+++ b/Dockerfile
@@ -311,6 +311,8 @@ COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 
 COPY --from=libkrun /libkrun-nerdbox-${KERNEL_ARCH}.so /usr/local/lib64/libkrun-nerdbox-${KERNEL_ARCH}.so
+RUN ln -s libkrun-nerdbox-${KERNEL_ARCH}.so /usr/local/lib64/libkrun-nerdbox.so && \
+    ln -s libkrun-nerdbox-${KERNEL_ARCH}.so /usr/local/lib64/libkrun.so
 ENV LIBKRUN_PATH=/go/src/github.com/containerd/nerdbox/_output
 
 VOLUME /var/lib/containerd

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ ifeq ($(OS),Darwin)
 endif
 
 _output/libkrun.so: FORCE
-	@echo "$(WHALE) $@"
-	$(BUILDX) bake libkrun
+	@task build:libkrun
 
 
 generate: protos

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,15 @@ tasks:
       - cmd: codesign --entitlements cmd/containerd-shim-nerdbox-v1/containerd-shim-nerdbox-v1.entitlements --force -s - {{.OUTPUT_DIR}}/containerd-shim-nerdbox-v1
         platforms: [darwin]
 
+  build:libkrun:
+    desc: Build libkrun via Docker Buildx Bake and create generic symlinks in _output/
+    cmds:
+      - KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake libkrun
+      - cmd: |
+          cd {{.OUTPUT_DIR}}
+          ln -sf libkrun-nerdbox-{{.KERNEL_ARCH}}.so libkrun-nerdbox.so
+          ln -sf libkrun-nerdbox-{{.KERNEL_ARCH}}.so libkrun.so
+
   build:guest:
     desc: Build guest artifacts (kernel and rootfs) via Docker Buildx Bake
     cmds:

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -78,39 +78,76 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 		p2 = []string{"/usr/local/lib", "/usr/local/lib64", "/usr/lib", "/lib"}
 	}
 	arch := kernelArch()
-	sharedNames := []string{fmt.Sprintf("libkrun-%s.so", arch), "libkrun.so"}
+
+	// variants lists distinct library families in priority order. Each family
+	// represents a different patchset / ABI, so we exhaust all search paths
+	// for one variant before falling back to the next. Within a variant, the
+	// arch-tagged name is preferred over the generic name.
+	//
+	// Priority: libkrun-nerdbox (custom patches) > libkrun (stock upstream)
+	variants := [][]string{
+		{fmt.Sprintf("libkrun-nerdbox-%s.so", arch), "libkrun-nerdbox.so"},
+		{fmt.Sprintf("libkrun-%s.so", arch), "libkrun.so"},
+	}
 	switch runtime.GOOS {
 	case "darwin":
-		sharedNames = []string{fmt.Sprintf("libkrun-%s.dylib", arch), "libkrun.dylib", fmt.Sprintf("libkrun-efi-%s.dylib", arch), "libkrun-efi.dylib"}
+		variants = [][]string{
+			{fmt.Sprintf("libkrun-nerdbox-%s.dylib", arch), "libkrun-nerdbox.dylib"},
+			{fmt.Sprintf("libkrun-%s.dylib", arch), "libkrun.dylib"},
+			{fmt.Sprintf("libkrun-efi-%s.dylib", arch), "libkrun-efi.dylib"},
+		}
 		p2 = append(p2, "/opt/homebrew/lib")
 	case "windows":
-		sharedNames = []string{"krun.dll"}
+		variants = [][]string{{"krun.dll"}}
 	}
 
-	for _, dir := range append(p1, p2...) {
-		if dir == "" {
-			// Unix shell semantics: path element "" means "."
-			dir = "."
+	dirs := append(p1, p2...)
+
+	// Search: variant → name → directory. All paths are checked for a given
+	// name before moving to the next name, and all names in a variant are
+	// exhausted before trying the next variant.
+	var sharedNames []string // flattened, for use in the error message
+	for _, variant := range variants {
+		sharedNames = append(sharedNames, variant...)
+	}
+	for _, variant := range variants {
+		if krunPath != "" {
+			break
 		}
-		var path string
-		if krunPath == "" {
-			for _, sharedName := range sharedNames {
-				path = filepath.Join(dir, sharedName)
+		for _, name := range variant {
+			if krunPath != "" {
+				break
+			}
+			for _, dir := range dirs {
+				if dir == "" {
+					// Unix shell semantics: path element "" means "."
+					dir = "."
+				}
+				path := filepath.Join(dir, name)
 				if _, err := os.Stat(path); err == nil {
 					krunPath = path
 					break
 				}
 			}
 		}
+	}
+
+	// Kernel and rootfs use a single name variant each; still search all dirs.
+	kernelName := fmt.Sprintf("nerdbox-kernel-%s", arch)
+	rootfsNames := []string{fmt.Sprintf("nerdbox-rootfs-%s.erofs", arch), "nerdbox-rootfs.erofs"}
+	for _, dir := range dirs {
+		if dir == "" {
+			dir = "."
+		}
 		if kernelPath == "" {
-			path = filepath.Join(dir, fmt.Sprintf("nerdbox-kernel-%s", kernelArch()))
+			path := filepath.Join(dir, kernelName)
 			if _, err := os.Stat(path); err == nil {
 				kernelPath = path
 			}
 		}
 		if rootfsPath == "" {
-			for _, name := range []string{fmt.Sprintf("nerdbox-rootfs-%s.erofs", arch), "nerdbox-rootfs.erofs"} {
-				path = filepath.Join(dir, name)
+			for _, name := range rootfsNames {
+				path := filepath.Join(dir, name)
 				if _, err := os.Stat(path); err == nil {
 					rootfsPath = path
 					break


### PR DESCRIPTION
Add variant name to our build of libkrun to prevent conflicting with libkrun that may be on the system.