### PR TITLE
fix(erofs): write per-instance VMDK descriptor to bundle dir; use atomic write

### DIFF
--- a/internal/erofs/vmdk.go
+++ b/internal/erofs/vmdk.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -33,10 +34,11 @@ const (
 
 // vmdkDescAddExtent writes extent lines to the writer.
 // Each extent line follows the format: RW <count> FLAT "<filename>" <offset>
+// A single device > 2 GiB is split across multiple RW lines, each referencing
+// the same filename with increasing sector offsets.
 func vmdkDescAddExtent(w io.Writer, sectors uint64, filename string, offset uint64) error {
 	for sectors > 0 {
 		count := min(sectors, max2GbExtentSectors)
-
 		_, err := fmt.Fprintf(w, "RW %d FLAT \"%s\" %d\n", count, filename, offset)
 		if err != nil {
 			return err
@@ -47,6 +49,8 @@ func vmdkDescAddExtent(w io.Writer, sectors uint64, filename string, offset uint
 	return nil
 }
 
+// DumpVMDKDescriptor writes a monolithicFlat VMDK descriptor to w.
+// Extent path strings are written verbatim from devices.
 func DumpVMDKDescriptor(w io.Writer, cid uint32, devices []string) error {
 	parentCID := uint32(0xffffffff)
 
@@ -70,8 +74,7 @@ createType="%s"
 			return err
 		}
 		sectors := uint64(fi.Size()) >> 9
-		err = vmdkDescAddExtent(w, sectors, d, 0)
-		if err != nil {
+		if err := vmdkDescAddExtent(w, sectors, d, 0); err != nil {
 			return err
 		}
 		totalSectors += sectors
@@ -89,18 +92,37 @@ ddb.geometry.heads = "%d"
 ddb.geometry.sectors = "63"
 ddb.adapterType = "%s"
 `, hwVersion, cylinders, numberHeads, adapterType)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-func DumpVMDKDescriptorToFile(vmdkdesc string, cid uint32, devices []string) error {
-	f, err := os.Create(vmdkdesc)
+// DumpVMDKDescriptorToFile writes a VMDK descriptor to path atomically.
+// It creates a uniquely-named temporary file in the same directory as path,
+// syncs it to disk, and renames it into place. This ensures that a concurrent
+// reader never observes a partially-written descriptor and that two concurrent
+// writers do not clobber each other's temporary file.
+func DumpVMDKDescriptorToFile(path string, cid uint32, devices []string) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "merged_fs.vmdk.*.tmp")
 	if err != nil {
 		return err
 	}
-	err = DumpVMDKDescriptor(f, cid, devices)
-	f.Close()
-	return err
+	tmpName := f.Name()
+
+	werr := DumpVMDKDescriptor(f, cid, devices)
+	serr := f.Sync()
+	cerr := f.Close()
+
+	if werr != nil {
+		os.Remove(tmpName)
+		return werr
+	}
+	if serr != nil {
+		os.Remove(tmpName)
+		return serr
+	}
+	if cerr != nil {
+		os.Remove(tmpName)
+		return cerr
+	}
+	return os.Rename(tmpName, path)
 }

--- a/internal/erofs/vmdk_test.go
+++ b/internal/erofs/vmdk_test.go
@@ -1,0 +1,127 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package erofs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeExtentFile creates a sparse file of the given size (in 512-byte sectors)
+// inside dir and returns its absolute path.
+func makeExtentFile(t *testing.T, dir, name string, sectors int) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(int64(sectors)*512))
+	require.NoError(t, f.Close())
+	return path
+}
+
+// tmpFilesIn returns the names of all files in dir whose name contains ".tmp".
+func tmpFilesIn(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var out []string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// TestDumpVMDKDescriptorToFile_Atomic verifies that DumpVMDKDescriptorToFile
+// does not leave any .tmp intermediate file behind after a successful write.
+func TestDumpVMDKDescriptorToFile_Atomic(t *testing.T) {
+	dir := t.TempDir()
+	ext := makeExtentFile(t, dir, "layer.erofs", 8)
+
+	descPath := filepath.Join(dir, "merged_fs.vmdk")
+	require.NoError(t, DumpVMDKDescriptorToFile(descPath, 0xfffffffe, []string{ext}))
+
+	_, err := os.Stat(descPath)
+	require.NoError(t, err, "descriptor file should exist")
+
+	assert.Empty(t, tmpFilesIn(t, dir), ".tmp files must not persist after a successful write")
+}
+
+// TestDumpVMDKDescriptorToFile_WriteFail verifies that DumpVMDKDescriptorToFile
+// cleans up the temporary file when the write fails (e.g. a missing device).
+func TestDumpVMDKDescriptorToFile_WriteFail(t *testing.T) {
+	dir := t.TempDir()
+	descPath := filepath.Join(dir, "merged_fs.vmdk")
+
+	err := DumpVMDKDescriptorToFile(descPath, 0xfffffffe, []string{"/nonexistent/layer.erofs"})
+	require.Error(t, err)
+
+	assert.Empty(t, tmpFilesIn(t, dir), ".tmp files must be cleaned up on write failure")
+	_, statErr := os.Stat(descPath)
+	assert.True(t, os.IsNotExist(statErr), "descriptor must not exist after a failed write")
+}
+
+// TestDumpVMDKDescriptorToFile_Regenerate verifies that calling
+// DumpVMDKDescriptorToFile twice on the same path atomically replaces the
+// descriptor each time and leaves no .tmp residue. This mirrors the
+// unconditional-regeneration behaviour used by transformMounts.
+func TestDumpVMDKDescriptorToFile_Regenerate(t *testing.T) {
+	dir := t.TempDir()
+	ext := makeExtentFile(t, dir, "layer.erofs", 8)
+	descPath := filepath.Join(dir, "merged_fs.vmdk")
+
+	require.NoError(t, DumpVMDKDescriptorToFile(descPath, 0xfffffffe, []string{ext}))
+
+	fi1, err := os.Stat(descPath)
+	require.NoError(t, err)
+
+	// Call again unconditionally — the second write must replace the file.
+	require.NoError(t, DumpVMDKDescriptorToFile(descPath, 0xfffffffe, []string{ext}))
+
+	fi2, err := os.Stat(descPath)
+	require.NoError(t, err)
+
+	// The descriptor must still exist and be readable.
+	_, statErr := os.Stat(descPath)
+	require.NoError(t, statErr, "descriptor must exist after second write")
+
+	// Size should be identical (same inputs), confirming the file was rewritten
+	// rather than skipped.
+	assert.Equal(t, fi1.Size(), fi2.Size(), "descriptor size must match between regenerations with the same inputs")
+	assert.Empty(t, tmpFilesIn(t, dir), ".tmp files must not persist after second write")
+}
+
+// TestDumpVMDKDescriptorToFile_MultipleDevices verifies that a descriptor
+// written for multiple extent files can be written and replaced successfully.
+func TestDumpVMDKDescriptorToFile_MultipleDevices(t *testing.T) {
+	dir := t.TempDir()
+	ext1 := makeExtentFile(t, dir, "layer0.erofs", 8)
+	ext2 := makeExtentFile(t, dir, "layer1.erofs", 4)
+
+	descPath := filepath.Join(dir, "merged_fs.vmdk")
+	require.NoError(t, DumpVMDKDescriptorToFile(descPath, 0xfffffffe, []string{ext1, ext2}))
+
+	_, err := os.Stat(descPath)
+	require.NoError(t, err, "descriptor file should exist after multi-device write")
+	assert.Empty(t, tmpFilesIn(t, dir), ".tmp files must not persist")
+}

--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -56,7 +56,7 @@ type diskOptions struct {
 
 // transformMounts does not perform any local mounts but transforms
 // the mounts to be used inside the VM via virtio
-func transformMounts(ctx context.Context, id string, ms []*types.Mount, da *diskAllocator) ([]*types.Mount, []sandbox.Opt, error) {
+func transformMounts(ctx context.Context, id string, ms []*types.Mount, da *diskAllocator, bundleDir string) ([]*types.Mount, []sandbox.Opt, error) {
 	var (
 		addDisks []diskOptions
 		am       []*types.Mount
@@ -87,18 +87,14 @@ func transformMounts(ctx context.Context, id string, ms []*types.Mount, da *disk
 			}
 
 			if len(devices) > 1 {
-				// generate VMDK desc for the EROFS flattened fs if it does not exist
-				mergedfsPath := filepath.Dir(m.Source) + "/merged_fs.vmdk"
-				if _, err := os.Stat(mergedfsPath); err != nil {
-					if !os.IsNotExist(err) {
-						log.G(ctx).Warnf("failed to stat %v: %v", mergedfsPath, err)
-						return nil, nil, errdefs.ErrNotImplemented
-					}
-					err = erofs.DumpVMDKDescriptorToFile(mergedfsPath, 0xfffffffe, devices)
-					if err != nil {
-						log.G(ctx).Warnf("failed to generate %v: %v", mergedfsPath, err)
-						return nil, nil, errdefs.ErrNotImplemented
-					}
+				// Write the VMDK descriptor into the per-instance bundle directory
+				// so it is torn down with the bundle and never shared across
+				// container instances. Regenerate unconditionally on every mount
+				// so the descriptor always reflects the current device list.
+				mergedfsPath := filepath.Join(bundleDir, "merged_fs.vmdk")
+				if err := erofs.DumpVMDKDescriptorToFile(mergedfsPath, 0xfffffffe, devices); err != nil {
+					log.G(ctx).Warnf("failed to generate %v: %v", mergedfsPath, err)
+					return nil, nil, errdefs.ErrNotImplemented
 				}
 				addDisks = append(addDisks, diskOptions{
 					name:     disk,

--- a/internal/shim/task/mount_linux.go
+++ b/internal/shim/task/mount_linux.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdbox/internal/shim/sandbox"
 )
 
-func setupMounts(ctx context.Context, id string, m []*types.Mount, rootfs, lmounts string, da *diskAllocator) ([]*types.Mount, []sandbox.Opt, error) {
+func setupMounts(ctx context.Context, id string, m []*types.Mount, rootfs, lmounts string, da *diskAllocator, bundleDir string) ([]*types.Mount, []sandbox.Opt, error) {
 	// Handle mounts
 	var sbOpts []sandbox.Opt
 
@@ -65,7 +65,7 @@ func setupMounts(ctx context.Context, id string, m []*types.Mount, rootfs, lmoun
 			Source: tag,
 		}}, sbOpts, nil
 	}
-	mounts, opts, err := transformMounts(ctx, id, m, da)
+	mounts, opts, err := transformMounts(ctx, id, m, da, bundleDir)
 	if err != nil && errdefs.IsNotImplemented(err) {
 		if err := mountutil.All(ctx, rootfs, lmounts, m); err != nil {
 			return nil, nil, err

--- a/internal/shim/task/mount_other.go
+++ b/internal/shim/task/mount_other.go
@@ -26,6 +26,6 @@ import (
 	"github.com/containerd/nerdbox/internal/shim/sandbox"
 )
 
-func setupMounts(ctx context.Context, id string, ms []*types.Mount, _, _ string, da *diskAllocator) ([]*types.Mount, []sandbox.Opt, error) {
-	return transformMounts(ctx, id, ms, da)
+func setupMounts(ctx context.Context, id string, ms []*types.Mount, _, _ string, da *diskAllocator, bundleDir string) ([]*types.Mount, []sandbox.Opt, error) {
+	return transformMounts(ctx, id, ms, da, bundleDir)
 }

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -261,7 +261,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	// da is shared across rootfs and volume disk allocation so that all
 	// virtio-block devices within a container get unique, sequential letters.
 	da := newDiskAllocator()
-	m, mountOpts, err := setupMounts(ctx, r.ID, r.Rootfs, b.Rootfs, filepath.Join(r.Bundle, "mounts"), &da)
+	m, mountOpts, err := setupMounts(ctx, r.ID, r.Rootfs, b.Rootfs, filepath.Join(r.Bundle, "mounts"), &da, r.Bundle)
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}


### PR DESCRIPTION
The `merged_fs.vmdk` descriptor was written to the snapshotter directory and reused across mounts via a bare existence check. If the backing extent files moved or were cleaned up, the cached descriptor became permanently stale with no recovery path.

Switch to a simpler, more correct design:

- **Per-instance descriptor**: write to the OCI bundle directory (`filepath.Join(bundleDir, "merged_fs.vmdk")`) so the file is scoped to one container lifetime and torn down with the bundle. No descriptor is shared across instances.
- **Unconditional regeneration**: regenerate on every `transformMounts` call — no existence check, no cache, no stale state possible.
- **Atomic write**: `os.CreateTemp` + `fsync` + `os.Rename` so concurrent writers each get a unique temporary filename and a reader never observes a partially-written file.

`bundleDir` is threaded through `setupMounts` and `transformMounts`; the erofs branch writes the descriptor to `filepath.Join(bundleDir, "merged_fs.vmdk")`.

No new public API is introduced.

```release-note
The erofs snapshotter now writes the VMDK extent descriptor to the per-instance bundle directory and regenerates it on every mount, eliminating the class of failures caused by stale cached descriptors.
```