### PR TITLE
ci: migrate GHA to task, remove duplicate unit test job

### DIFF
--- a/.github/workflows/build-shim.yml
+++ b/.github/workflows/build-shim.yml
@@ -39,10 +39,15 @@ jobs:
         with:
           go-version-file: '.github/.tool-versions'
 
+      - uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa  # v2.1.0
+        with:
+          version: 3.x
+
       - name: Build shim
-        run: |
-          mkdir -p _output
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o _output/containerd-shim-nerdbox-v1${{ matrix.suffix }} -ldflags '-s -w' -tags 'no_grpc' ./cmd/containerd-shim-nerdbox-v1
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: task build:shim
 
       - name: Verify binary
         run: file _output/containerd-shim-nerdbox-v1${{ matrix.suffix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,22 +145,6 @@ jobs:
       - run: task check-api-descriptors
 
   #
-  # Unit tests
-  #
-  tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version-file: '.github/.tool-versions'
-      - name: Run unit tests
-        run: go test -race -count=1 $(go list ./... | grep -v /integration)
-
-  #
   # Fuzz tests
   #
   fuzz:
@@ -169,22 +153,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: '.github/.tool-versions'
+      - uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa  # v2.1.0
+        with:
+          version: 3.x
       - name: Run all fuzz tests
-        run: |
-          # Find all packages containing fuzz tests and run each target.
-          # go test -fuzz only accepts one package at a time and one
-          # matching fuzz target, so we discover and iterate.
-          grep -r --include='*_test.go' -l '^func Fuzz' . | while read -r file; do
-            pkg=$(dirname "$file")
-            grep -o '^func Fuzz[A-Za-z0-9_]*' "$file" | sed 's/^func //' | while read -r target; do
-              echo "=== Fuzzing ${target} in ${pkg} ==="
-              go test "${pkg}" -fuzz="^${target}$" -fuzztime=60s
-            done
-          done
+        run: task test:fuzz
 
   #
   # Build kernels on cache miss

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,10 +23,18 @@ tasks:
       - HOST_OS={{OS}} KERNEL_ARCH={{.KERNEL_ARCH}} docker buildx bake
 
   build:shim:
-    desc: Build containerd-shim-nerdbox-v1 for the current platform
+    desc: "Build containerd-shim-nerdbox-v1. Override target with GOOS/GOARCH env vars for cross-compilation."
+    vars:
+      # Resolve target GOOS/GOARCH: env vars override, then fall back to
+      # the Go toolchain's native values.
+      TARGET_GOOS:
+        sh: 'if [ -n "$GOOS" ]; then echo "$GOOS"; else go env GOOS; fi'
+      TARGET_GOARCH:
+        sh: 'if [ -n "$GOARCH" ]; then echo "$GOARCH"; else go env GOARCH; fi'
+      TARGET_SUFFIX: '{{if eq .TARGET_GOOS "windows"}}.exe{{end}}'
     cmds:
       - mkdir -p {{.OUTPUT_DIR}}
-      - go build {{.GO_TAGS}} {{.GO_LDFLAGS}} -o {{.OUTPUT_DIR}}/containerd-shim-nerdbox-v1{{if eq OS "windows"}}.exe{{end}} ./cmd/containerd-shim-nerdbox-v1
+      - GOOS={{.TARGET_GOOS}} GOARCH={{.TARGET_GOARCH}} go build {{.GO_TAGS}} {{.GO_LDFLAGS}} -o {{.OUTPUT_DIR}}/containerd-shim-nerdbox-v1{{.TARGET_SUFFIX}} ./cmd/containerd-shim-nerdbox-v1
       - cmd: codesign --entitlements cmd/containerd-shim-nerdbox-v1/containerd-shim-nerdbox-v1.entitlements --force -s - {{.OUTPUT_DIR}}/containerd-shim-nerdbox-v1
         platforms: [darwin]
 
@@ -71,6 +79,24 @@ tasks:
     desc: Run unit tests (excludes integration and shim test packages)
     cmds:
       - go test -count=1 ./api/... ./cmd/... ./internal/... ./pkg/... ./plugins/...
+
+  test:fuzz:
+    desc: "Run all fuzz targets for a short duration (default 60s each). Override with FUZZTIME env var: FUZZTIME=30s task test:fuzz"
+    vars:
+      FUZZTIME: '{{default "60s" .FUZZTIME}}'
+    cmds:
+      - cmd: |
+          # Find all packages containing fuzz tests and run each target.
+          # go test -fuzz only accepts one package at a time and one
+          # matching fuzz target, so we discover and iterate.
+          grep -r --include='*_test.go' -l '^func Fuzz' . --exclude-dir=test | while read -r file; do
+            pkg=$(dirname "$file")
+            grep -o '^func Fuzz[A-Za-z0-9_]*' "$file" | sed 's/^func //' | while read -r target; do
+              echo "=== Fuzzing ${target} in ${pkg} ==="
+              go test "${pkg}" -fuzz="^${target}$" -fuzztime={{.FUZZTIME}}
+            done
+          done
+        platforms: [linux, darwin]
 
   test:integration:
     desc: "Run integration tests (each test in its own process). Extra flags are forwarded to the test binary: task test:integration -- -run TestSystemInfo -v"


### PR DESCRIPTION
Add test:fuzz and cross-compilation support to build:shim in Taskfile.yml. Update fuzz and build-shim workflows to use task. Remove the duplicate tests job introduced alongside the fuzz job.