### PR TITLE
Construct guest runc options rather than forwarding host options

### DIFF
--- a/internal/shim/task/options_test.go
+++ b/internal/shim/task/options_test.go
@@ -1,0 +1,203 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"testing"
+
+	runcOptions "github.com/containerd/containerd/api/types/runc/options"
+	"github.com/containerd/typeurl/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// marshalRuncOpts is a test helper that marshals runc Options into an *anypb.Any.
+func marshalRuncOpts(t *testing.T, o *runcOptions.Options) *anypb.Any {
+	t.Helper()
+	a, err := typeurl.MarshalAny(o)
+	if err != nil {
+		t.Fatalf("marshalRuncOpts: %v", err)
+	}
+	return typeurl.MarshalProto(a)
+}
+
+// decodeRuncOpts is a test helper that decodes an *anypb.Any back to runc Options.
+func decodeRuncOpts(t *testing.T, a *anypb.Any) *runcOptions.Options {
+	t.Helper()
+	v, err := typeurl.UnmarshalAny(a)
+	if err != nil {
+		t.Fatalf("decodeRuncOpts: %v", err)
+	}
+	out, ok := v.(*runcOptions.Options)
+	if !ok {
+		t.Fatalf("decodeRuncOpts: unexpected type %T", v)
+	}
+	return out
+}
+
+func TestGuestRuncOptions_NilOrEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// nil Any
+	got, err := guestRuncOptions(ctx, nil)
+	if err != nil {
+		t.Fatalf("nil opts: unexpected error: %v", err)
+	}
+	out := decodeRuncOpts(t, got)
+	if out.NoPivotRoot || out.NoNewKeyring {
+		t.Errorf("nil opts: expected zero output, got %v", out)
+	}
+
+	// non-nil but empty value
+	got, err = guestRuncOptions(ctx, &anypb.Any{})
+	if err != nil {
+		t.Fatalf("empty opts: unexpected error: %v", err)
+	}
+	out = decodeRuncOpts(t, got)
+	if out.NoPivotRoot || out.NoNewKeyring {
+		t.Errorf("empty opts: expected zero output, got %v", out)
+	}
+}
+
+func TestGuestRuncOptions_AllowListedFieldsForwarded(t *testing.T) {
+	ctx := context.Background()
+
+	in := marshalRuncOpts(t, &runcOptions.Options{
+		NoPivotRoot:  true,
+		NoNewKeyring: true,
+	})
+	got, err := guestRuncOptions(ctx, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeRuncOpts(t, got)
+	if !out.NoPivotRoot {
+		t.Error("NoPivotRoot should be forwarded")
+	}
+	if !out.NoNewKeyring {
+		t.Error("NoNewKeyring should be forwarded")
+	}
+}
+
+func TestGuestRuncOptions_HostFieldsStripped(t *testing.T) {
+	ctx := context.Background()
+
+	in := marshalRuncOpts(t, &runcOptions.Options{
+		NoPivotRoot: true,
+		// host-only fields
+		Root:           "/run/containerd/runc",
+		BinaryName:     "/usr/bin/runc",
+		ShimCgroup:     "system.slice/containerd.service",
+		IoUid:          1000,
+		IoGid:          1000,
+		TaskApiAddress: "/run/containerd/s/abc123",
+	})
+	got, err := guestRuncOptions(ctx, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeRuncOpts(t, got)
+
+	// Allow-listed field preserved.
+	if !out.NoPivotRoot {
+		t.Error("NoPivotRoot should be forwarded")
+	}
+	// Host-only fields must be zero.
+	if out.Root != "" {
+		t.Errorf("Root should be stripped, got %q", out.Root)
+	}
+	if out.BinaryName != "" {
+		t.Errorf("BinaryName should be stripped, got %q", out.BinaryName)
+	}
+	if out.ShimCgroup != "" {
+		t.Errorf("ShimCgroup should be stripped, got %q", out.ShimCgroup)
+	}
+	if out.IoUid != 0 {
+		t.Errorf("IoUid should be stripped, got %d", out.IoUid)
+	}
+	if out.IoGid != 0 {
+		t.Errorf("IoGid should be stripped, got %d", out.IoGid)
+	}
+	if out.TaskApiAddress != "" {
+		t.Errorf("TaskApiAddress should be stripped, got %q", out.TaskApiAddress)
+	}
+}
+
+func TestGuestRuncOptions_WarnedFieldsStripped(t *testing.T) {
+	ctx := context.Background()
+
+	in := marshalRuncOpts(t, &runcOptions.Options{
+		SystemdCgroup: true,
+		CriuImagePath: "/host/criu/images",
+		CriuWorkPath:  "/host/criu/work",
+	})
+	got, err := guestRuncOptions(ctx, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeRuncOpts(t, got)
+
+	if out.SystemdCgroup {
+		t.Error("SystemdCgroup should not be forwarded to guest")
+	}
+	if out.CriuImagePath != "" {
+		t.Errorf("CriuImagePath should not be forwarded, got %q", out.CriuImagePath)
+	}
+	if out.CriuWorkPath != "" {
+		t.Errorf("CriuWorkPath should not be forwarded, got %q", out.CriuWorkPath)
+	}
+}
+
+func TestGuestRuncOptions_UnknownTypeReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	// Craft an Any with a foreign type URL to simulate a non-runc options type.
+	a := &anypb.Any{
+		TypeUrl: "type.googleapis.com/some.other.Options",
+		Value:   []byte{0x0a, 0x03, 0x66, 0x6f, 0x6f}, // arbitrary bytes
+	}
+	_, err := guestRuncOptions(ctx, a)
+	if err == nil {
+		t.Fatal("expected error for unknown options type, got nil")
+	}
+}
+
+func TestGuestRuncOptions_FreshInstanceEachCall(t *testing.T) {
+	ctx := context.Background()
+
+	in := marshalRuncOpts(t, &runcOptions.Options{NoPivotRoot: true})
+
+	got1, err := guestRuncOptions(ctx, in)
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	got2, err := guestRuncOptions(ctx, in)
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+
+	// The two results should be equal in content but must be distinct allocations.
+	if got1 == got2 {
+		t.Error("guestRuncOptions should return a new *Any each call")
+	}
+	out1 := decodeRuncOpts(t, got1)
+	out2 := decodeRuncOpts(t, got2)
+	if !proto.Equal(out1, out2) {
+		t.Error("two calls with same input should produce equal output")
+	}
+}

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -29,6 +29,7 @@ import (
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/api/types"
+	runcOptions "github.com/containerd/containerd/api/types/runc/options"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -39,6 +40,7 @@ import (
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
 
 	bundleAPI "github.com/containerd/nerdbox/api/services/bundle/v1"
 	mountAPI "github.com/containerd/nerdbox/api/services/mount/v1"
@@ -52,6 +54,69 @@ var (
 	_     = shim.TTRPCService(&service{})
 	empty = &ptypes.Empty{}
 )
+
+// guestRuncOptions constructs a fresh runc Options message containing only the
+// fields that are meaningful inside the VM guest, and returns it as a
+// marshalled Any suitable for forwarding to vminitd.
+//
+// The runc Options proto conflates two distinct concerns:
+//
+//   - Host-side shim configuration: ShimCgroup, IoUid, IoGid, BinaryName, Root,
+//     and TaskApiAddress. These reference host UID/GID values and host filesystem
+//     paths and have no meaning inside the VM.
+//
+//   - Guest-side container configuration: NoPivotRoot, NoNewKeyring.
+//     These affect how the OCI runtime inside the VM sets up the container
+//     and are forwarded.
+//
+// Fields that are explicitly not forwarded, with a warning logged if set:
+//
+//   - SystemdCgroup: the VM has no systemd; the in-guest crun always uses the
+//     cgroupsv2 fs driver.
+//   - CriuImagePath / CriuWorkPath: host filesystem paths for checkpoint images;
+//     checkpoint/restore is coordinated at the VM level by the shim.
+//
+// A new Options message is always constructed rather than filtering the incoming
+// one, so that any unrecognised or future fields default to zero inside the guest.
+// If opts is nil or empty, an empty Options is returned (zero values).
+// If opts is not a runc Options message an error is returned; the shim knows the
+// guest runtime and passing through an opaque blob would be unsafe.
+func guestRuncOptions(ctx context.Context, opts *ptypes.Any) (*ptypes.Any, error) {
+	out := &runcOptions.Options{}
+
+	if opts.GetTypeUrl() != "" {
+		v, err := typeurl.UnmarshalAny(opts)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to decode task options: %w", errdefs.ErrInvalidArgument, err)
+		}
+		src, ok := v.(*runcOptions.Options)
+		if !ok {
+			return nil, fmt.Errorf("%w: unsupported options type %T, guest runtime only supports runc options", errdefs.ErrInvalidArgument, v)
+		}
+
+		// Allow-listed fields that are meaningful inside the VM.
+		out.NoPivotRoot = src.NoPivotRoot
+		out.NoNewKeyring = src.NoNewKeyring
+
+		// Warn about fields that were set but will not be forwarded, so the
+		// caller knows the guest will not honour them.
+		if src.SystemdCgroup {
+			log.G(ctx).Warn("task options: SystemdCgroup ignored — the VM guest has no systemd; crun uses the cgroupsv2 fs driver")
+		}
+		if src.CriuImagePath != "" {
+			log.G(ctx).WithField("criu_image_path", src.CriuImagePath).Warn("task options: CriuImagePath ignored — checkpoint/restore is coordinated at the VM level")
+		}
+		if src.CriuWorkPath != "" {
+			log.G(ctx).WithField("criu_work_path", src.CriuWorkPath).Warn("task options: CriuWorkPath ignored — checkpoint/restore is coordinated at the VM level")
+		}
+	}
+
+	a, err := typeurl.MarshalAny(out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal guest runc options: %w", err)
+	}
+	return typeurl.MarshalProto(a), nil
+}
 
 // NewTaskService creates a new instance of a task service
 func NewTaskService(ctx context.Context, sb sandbox.Sandbox, publisher shim.Publisher, sd shutdown.Service) (taskAPI.TTRPCTaskService, error) {
@@ -409,6 +474,14 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		execShutdowns: make(map[string]func(context.Context) error),
 	}
 
+	guestOpts, err := guestRuncOptions(ctx, r.Options)
+	if err != nil {
+		if err := ioShutdown(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("failed to shutdown io after options error")
+		}
+		return nil, errgrpc.ToGRPC(fmt.Errorf("invalid task options: %w", err))
+	}
+
 	tc := taskAPI.NewTTRPCTaskClient(vmc)
 	resp, err := tc.Create(ctx, &taskAPI.CreateTaskRequest{
 		ID:       r.ID,
@@ -418,7 +491,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		Stdin:    cio.Stdin,
 		Stdout:   cio.Stdout,
 		Stderr:   cio.Stderr,
-		Options:  r.Options,
+		Options:  guestOpts,
 	})
 	if err != nil {
 		log.G(ctx).WithError(err).Error("failed to create task")


### PR DESCRIPTION
The runc Options proto mixes host-side shim config with guest-side
container config. Rather than filtering the incoming blob, always
construct a fresh Options for the guest with only the fields that are
meaningful inside the VM:

  NoPivotRoot, NoNewKeyring  forwarded
  SystemdCgroup, Criu*       dropped with a warning log (no systemd in
                             guest; checkpoint coordinated at VM level)
  Root, BinaryName,          dropped silently (host paths / identity,
  ShimCgroup, IoUid/IoGid,   meaningless inside the VM)
  TaskApiAddress

An unrecognised options type is rejected with InvalidArgument rather
than forwarded opaquely; the shim knows the guest runtime.
