### PR TITLE
shim: open output FIFO write end probe-first

### DIFF
--- a/internal/shim/task/io_copystreams_unix.go
+++ b/internal/shim/task/io_copystreams_unix.go
@@ -26,9 +26,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/containerd/fifo"
 	"github.com/containerd/log"
+	"golang.org/x/sys/unix"
 )
 
 func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdout, stderr string, done chan struct{}) error {
@@ -97,10 +99,14 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 			fr io.Closer
 		)
 		if ok {
-			if fw, err = fifo.OpenFifo(ctx, i.name, syscall.O_WRONLY, 0); err != nil {
+			// Open the write end probe-first so binding never blocks waiting
+			// for the reader and fails fast if none appears, then open a
+			// read-end holder so a later reader detach doesn't EOF our writer.
+			if fw, err = openFifoWriteRendezvous(ctx, i.name); err != nil {
 				return fmt.Errorf("containerd-shim: opening w/o fifo %q failed: %w", i.name, err)
 			}
 			if fr, err = fifo.OpenFifo(ctx, i.name, syscall.O_RDONLY, 0); err != nil {
+				fw.Close()
 				return fmt.Errorf("containerd-shim: opening r/o fifo %q failed: %w", i.name, err)
 			}
 		} else {
@@ -136,4 +142,55 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 	}
 	cwg.Wait()
 	return nil
+}
+
+const (
+	// fifoRendezvousTimeout bounds how long binding waits for the reader to
+	// open an output FIFO before giving up; the shim surfaces the failure
+	// as DEADLINE_EXCEEDED.
+	fifoRendezvousTimeout = 30 * time.Second
+	// fifoRendezvousBackoff is the poll interval while no reader is present.
+	fifoRendezvousBackoff = 10 * time.Millisecond
+)
+
+// openFifoWriteRendezvous opens the write end of a FIFO without blocking on a
+// reader. open(O_WRONLY|O_NONBLOCK) returns ENXIO while no reader is open, so
+// we poll until a reader appears, ctx is cancelled, or fifoRendezvousTimeout
+// elapses — binding never stalls at start and fails fast if the reader never
+// arrives. Once open, O_NONBLOCK is cleared so io.Copy's writes block on a
+// full pipe (backpressure) instead of spinning on EAGAIN.
+//
+// O_NOFOLLOW guards client-supplied paths: a symlink swapped in after validation
+// must not redirect the shim's writes to another file. The read-end holder and
+// stdin instead go through containerd/fifo, which reopens by /proc/self/fd handle
+// (itself a symlink, and already dev/ino-verified), so O_NOFOLLOW must not be set
+// there - it would fail that reopen with ELOOP.
+func openFifoWriteRendezvous(ctx context.Context, path string) (*os.File, error) {
+	ctx, cancel := context.WithTimeout(ctx, fifoRendezvousTimeout)
+	defer cancel()
+	for {
+		fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
+		if err == nil {
+			// Clear O_NONBLOCK so io.Copy's writes block on a full pipe
+			// (backpressure) instead of spinning on EAGAIN. If that fails,
+			// fail the open and close the fd.
+			fl, ferr := unix.FcntlInt(uintptr(fd), syscall.F_GETFL, 0)
+			if ferr == nil {
+				_, ferr = unix.FcntlInt(uintptr(fd), syscall.F_SETFL, fl&^syscall.O_NONBLOCK)
+			}
+			if ferr != nil {
+				syscall.Close(fd)
+				return nil, fmt.Errorf("clearing O_NONBLOCK on %q: %w", path, ferr)
+			}
+			return os.NewFile(uintptr(fd), path), nil
+		}
+		if err != syscall.ENXIO {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(fifoRendezvousBackoff):
+		}
+	}
 }

--- a/internal/shim/task/io_copystreams_unix_test.go
+++ b/internal/shim/task/io_copystreams_unix_test.go
@@ -1,0 +1,177 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// makeFifo creates a FIFO in a fresh temp dir and returns its path.
+func makeFifo(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fifo")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	return path
+}
+
+// openReaderRaw opens the read end of a FIFO without blocking. It touches no
+// *testing.T, so it is safe to call from a goroutine. Holding a reader open
+// lets the write-end open succeed.
+func openReaderRaw(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// openReader opens the read end of a FIFO and registers it for cleanup. Must be
+// called from the test goroutine.
+func openReader(t *testing.T, path string) *os.File {
+	t.Helper()
+	r, err := openReaderRaw(path)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+
+// TestOpenFifoWriteRendezvousReaderPresent: with a reader already open, the
+// write end opens immediately, has O_NONBLOCK cleared (so writes block for
+// backpressure), and bytes flow through to the reader.
+func TestOpenFifoWriteRendezvousReaderPresent(t *testing.T) {
+	path := makeFifo(t)
+	r := openReader(t, path)
+
+	fw, err := openFifoWriteRendezvous(t.Context(), path)
+	if err != nil {
+		t.Fatalf("rendezvous with reader present: %v", err)
+	}
+	defer fw.Close()
+
+	fl, err := unix.FcntlInt(fw.Fd(), syscall.F_GETFL, 0)
+	if err != nil {
+		t.Fatalf("F_GETFL: %v", err)
+	}
+	if fl&syscall.O_NONBLOCK != 0 {
+		t.Fatal("expected O_NONBLOCK to be cleared on the write fd")
+	}
+
+	if _, err := fw.Write([]byte("x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := r.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if buf[0] != 'x' {
+		t.Fatalf("got %q, want \"x\"", buf)
+	}
+}
+
+// TestOpenFifoWriteRendezvousReaderArrivesLate: the open must not stall at
+// start; it polls past ENXIO and succeeds once a reader shows up.
+func TestOpenFifoWriteRendezvousReaderArrivesLate(t *testing.T) {
+	path := makeFifo(t)
+
+	type readerResult struct {
+		r   *os.File
+		err error
+	}
+	// Buffered so the goroutine never blocks on send, and never touches t.
+	ready := make(chan readerResult, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		r, err := openReaderRaw(path)
+		ready <- readerResult{r: r, err: err}
+	}()
+
+	start := time.Now()
+	fw, err := openFifoWriteRendezvous(t.Context(), path)
+	if err != nil {
+		t.Fatalf("rendezvous with late reader: %v", err)
+	}
+	defer fw.Close()
+
+	res := <-ready
+	if res.err != nil {
+		t.Fatalf("open reader: %v", res.err)
+	}
+	t.Cleanup(func() { res.r.Close() })
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("rendezvous returned in %s; expected it to wait for the reader", elapsed)
+	}
+}
+
+// TestOpenFifoWriteRendezvousNoReaderTimesOut: with no reader ever opening,
+// the open fails fast once the context deadline elapses rather than blocking
+// forever.
+func TestOpenFifoWriteRendezvousNoReaderTimesOut(t *testing.T) {
+	path := makeFifo(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	fw, err := openFifoWriteRendezvous(ctx, path)
+	if err == nil {
+		fw.Close()
+		t.Fatal("expected an error with no reader present, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("rendezvous took %s to give up; expected it to honor the context deadline", elapsed)
+	}
+}
+
+// TestOpenFifoWriteRendezvousRejectsSymlink: O_NOFOLLOW must reject a symlinked
+// final path component (a client-supplied path swapped for a symlink after the
+// daemon validated it), even with a reader present.
+func TestOpenFifoWriteRendezvousRejectsSymlink(t *testing.T) {
+	path := makeFifo(t)
+	openReader(t, path)
+
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	fw, err := openFifoWriteRendezvous(t.Context(), link)
+	if err == nil {
+		fw.Close()
+		t.Fatal("expected O_NOFOLLOW to reject the symlinked path, got nil")
+	}
+	if !errors.Is(err, syscall.ELOOP) {
+		t.Fatalf("got %v, want ELOOP", err)
+	}
+}

--- a/internal/shim/task/io_copystreams_windows.go
+++ b/internal/shim/task/io_copystreams_windows.go
@@ -20,8 +20,11 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"net"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -90,14 +93,14 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 		}
 
 		var (
-			fw io.WriteCloser
+			fw  io.WriteCloser
 			err error
 		)
 
 		// On Windows, check if the path is a named pipe (\\.\pipe\...).
 		// Otherwise, fall back to regular file I/O.
 		if isNamedPipe(i.name) {
-			fw, err = winio.DialPipe(i.name, &pipeDialTimeout)
+			fw, err = dialPipeWaiting(ctx, i.name)
 			if err != nil {
 				return fmt.Errorf("containerd-shim: connecting to named pipe %q failed: %w", i.name, err)
 			}
@@ -119,7 +122,7 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 	if stdin != "" {
 		var f io.ReadCloser
 		if isNamedPipe(stdin) {
-			conn, err := winio.DialPipe(stdin, &pipeDialTimeout)
+			conn, err := dialPipeWaiting(ctx, stdin)
 			if err != nil {
 				return fmt.Errorf("containerd-shim: connecting to named pipe %q for stdin failed: %w", stdin, err)
 			}
@@ -151,4 +154,43 @@ func isNamedPipe(path string) bool {
 	return len(path) > 9 && path[:9] == `\\.\pipe\`
 }
 
-var pipeDialTimeout = 5 * time.Second
+// dialPipeWaiting dials the named pipe at path, waiting for the pipe to be
+// created if it does not exist yet. winio.DialPipe already retries while the
+// pipe exists but all server instances are busy (ERROR_PIPE_BUSY); it fails
+// immediately if the pipe does not exist (ERROR_FILE_NOT_FOUND). For client-owned
+// process I/O, the consumer is the pipe server and may not have called ListenPipe
+// yet when the shim binds stdio, so we also poll through "not found" until
+// ctx is cancelled or pipeConnectTimeout elapses.
+func dialPipeWaiting(ctx context.Context, path string) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(ctx, pipeConnectTimeout)
+	defer cancel()
+	for {
+		// DialPipeContext honors ctx promptly — including while it retries a
+		// busy pipe (ERROR_PIPE_BUSY) — so a caller's cancellation or deadline
+		// is observed within winio's 10ms retry granularity rather than after a
+		// fixed per-dial timeout. It returns immediately when the pipe does not
+		// exist yet (ERROR_FILE_NOT_FOUND), which we treat as "not ready" and
+		// poll below.
+		conn, err := winio.DialPipeContext(ctx, path)
+		if err == nil {
+			return conn, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pipeNotFoundPoll):
+		}
+	}
+}
+
+// pipeConnectTimeout bounds the overall connect: waiting both for a busy pipe's
+// server instance to free up (ERROR_PIPE_BUSY) and for a not-yet-created pipe
+// server to come up (ERROR_FILE_NOT_FOUND).
+var pipeConnectTimeout = 30 * time.Second
+
+// pipeNotFoundPoll is the backoff between dial attempts while the pipe does
+// not yet exist.
+const pipeNotFoundPoll = 20 * time.Millisecond

--- a/internal/shim/task/io_copystreams_windows_test.go
+++ b/internal/shim/task/io_copystreams_windows_test.go
@@ -1,0 +1,127 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// uniquePipePath returns a process-unique named-pipe path for a test.
+func uniquePipePath(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf(`\\.\pipe\nerdbox-test-%d`, time.Now().UnixNano())
+}
+
+// startPipeServer calls ListenPipe and, on success, spawns a goroutine that
+// accepts and immediately closes a single connection. It touches no *testing.T,
+// so it is safe to call from a goroutine; the listener (or the ListenPipe
+// error) is returned to the caller, which owns assertions and cleanup.
+func startPipeServer(path string) (net.Listener, error) {
+	l, err := winio.ListenPipe(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		if c, aerr := l.Accept(); aerr == nil {
+			c.Close()
+		}
+	}()
+	return l, nil
+}
+
+// TestDialPipeWaitingServerPresent: an existing pipe server connects on the
+// first dial, exactly like winio.DialPipe.
+func TestDialPipeWaitingServerPresent(t *testing.T) {
+	path := uniquePipePath(t)
+	l, err := startPipeServer(path)
+	if err != nil {
+		t.Fatalf("ListenPipe: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	conn, err := dialPipeWaiting(t.Context(), path)
+	if err != nil {
+		t.Fatalf("dial with server present: %v", err)
+	}
+	conn.Close()
+}
+
+// TestDialPipeWaitingServerArrivesLate: dialing must poll past
+// ERROR_FILE_NOT_FOUND and connect once the server calls ListenPipe.
+func TestDialPipeWaitingServerArrivesLate(t *testing.T) {
+	path := uniquePipePath(t)
+
+	type serverResult struct {
+		l   net.Listener
+		err error
+	}
+	// Buffered so the goroutine never blocks on send, and never touches t.
+	ready := make(chan serverResult, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		l, err := startPipeServer(path)
+		ready <- serverResult{l: l, err: err}
+	}()
+
+	start := time.Now()
+	conn, err := dialPipeWaiting(t.Context(), path)
+	if err != nil {
+		t.Fatalf("dial with late server: %v", err)
+	}
+	conn.Close()
+
+	res := <-ready
+	if res.err != nil {
+		t.Fatalf("ListenPipe: %v", res.err)
+	}
+	t.Cleanup(func() { res.l.Close() })
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("dial returned in %s; expected it to wait for the server", elapsed)
+	}
+}
+
+// TestDialPipeWaitingNoServerTimesOut: with no server, dialing fails fast once
+// the context deadline elapses rather than blocking forever.
+func TestDialPipeWaitingNoServerTimesOut(t *testing.T) {
+	path := uniquePipePath(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := dialPipeWaiting(ctx, path)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected an error with no server present, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("dial took %s to give up; expected it to honor the context deadline", elapsed)
+	}
+}


### PR DESCRIPTION
Open the output FIFOs probing for the reader end first bounded by context and hardcoded timeout to prevent blocking. Similarly for Windows named pipes, spin if file not found bounded by context and same hardcoded timeout. Surface timeouts as DEADLINE_EXCEEDED errors.