### PR TITLE
fix(virtiofs): scope host-edge read-only to directory bind mounts

### DIFF
--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -369,27 +369,35 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 		// the mounted directory.
 		hostSrc := m.Source
 		specSrc := vmTarget
-		if !fi.IsDir() {
+		readOnly := false
+		if fi.IsDir() {
+			// Honor a read-only request from the OCI spec by marking the
+			// virtiofs share read-only at the host edge. The guest `ro`
+			// mount option preserved in the OCI spec acts as defense in
+			// depth. Match typical mount-option semantics: scan all options
+			// without short-circuiting so that later `rw` overrides an
+			// earlier `ro` (and vice-versa).
+			//
+			// Only directory mounts get host-edge read-only: a file mount
+			// shares its *parent* directory (see the else branch), which also
+			// holds unrelated writable files — the container's own runtime
+			// state and stdio fifos live there — so marking that whole share
+			// read-only would wrongly deny those writes and stall container
+			// start. A read-only file mount is still honored by the guest `ro`
+			// OCI mount preserved in the spec.
+			for _, opt := range m.Options {
+				switch opt {
+				case "ro":
+					readOnly = true
+				case "rw":
+					readOnly = false
+				}
+			}
+		} else {
 			hostSrc = filepath.Dir(m.Source)
 			// Use path.Join (not filepath.Join) because this path is used
 			// inside the Linux VM where forward slashes are required.
 			specSrc = path.Join(vmTarget, filepath.Base(m.Source))
-		}
-
-		// Honor a read-only request from the OCI spec by marking the
-		// virtiofs share read-only at the host edge. The guest `ro`
-		// mount option preserved in the OCI spec acts as defense in
-		// depth. Match typical mount-option semantics: scan all options
-		// without short-circuiting so that later `rw` overrides an
-		// earlier `ro` (and vice-versa).
-		readOnly := false
-		for _, opt := range m.Options {
-			switch opt {
-			case "ro":
-				readOnly = true
-			case "rw":
-				readOnly = false
-			}
 		}
 
 		transformed := bindMount{

--- a/internal/shim/task/mount_test.go
+++ b/internal/shim/task/mount_test.go
@@ -242,6 +242,11 @@ func TestBindMountsProvider(t *testing.T) {
 			},
 		},
 		{
+			// A read-only *file* bind mount is backed by sharing its parent
+			// directory (virtio-fs operates on directories), so the share itself
+			// must stay writable — the parent holds unrelated writable siblings.
+			// The file keeps its read-only guarantee via the guest `ro` mount
+			// preserved in wantSpecSources. Hence readOnly/Readonly are false.
 			name: "single file bind mount read-only",
 			mounts: []specs.Mount{
 				{Type: "bind", Source: testfile, Destination: "/container/testfile", Options: []string{"bind", "ro"}},
@@ -251,7 +256,7 @@ func TestBindMountsProvider(t *testing.T) {
 					tag:      "bind-6dace5108a719565",
 					hostSrc:  tmpDir,
 					vmTarget: "/run/mnt/bind-6dace5108a719565",
-					readOnly: true,
+					readOnly: false,
 				},
 			},
 			wantSpecSources: []string{"/run/mnt/bind-6dace5108a719565/testfile.txt"},
@@ -259,7 +264,7 @@ func TestBindMountsProvider(t *testing.T) {
 				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/run/mnt/bind-6dace5108a719565"},
 			},
 			wantFS: []sandbox.Filesystem{
-				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: true},
+				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: false},
 			},
 		},
 		{


### PR DESCRIPTION
## Problem

`bindMounter` marks a virtio-fs share read-only at the host edge whenever the OCI bind mount carries the `ro` option. For a **file** bind mount this is incorrect: virtio-fs operates on directories, so a file mount is backed by sharing its **parent directory**. That parent typically contains unrelated *writable* files — the container's own runtime state and stdio fifos — so flagging the whole share read-only at the host edge denies writes to those siblings and stalls container start.

## Fix

Only directory bind mounts get host-edge read-only, where the shared device maps exactly to the read-only mount. A read-only **file** bind mount keeps its read-only guarantee through the guest `ro` mount option that is still preserved in the OCI spec (defense in depth — unchanged behavior for files).

## Test plan

- `go build ./...`
- Directory `ro` bind mount: writes are rejected at the host edge and cannot be re-enabled from inside the guest.
- File `ro` bind mount: container starts normally; sibling runtime files in the shared parent stay writable; the mounted file itself stays read-only via the guest mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
