### PR TITLE
Update libkrun to 1.19 with fixes for failed tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,7 +263,7 @@ FROM "${GOLANG_IMAGE}" AS dlv
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM "${RUST_IMAGE}" AS libkrun-build
-ARG LIBKRUN_VERSION=v1.18.1
+ARG LIBKRUN_VERSION=v1.19.0
 # Pin to the commit that fixes get_extent_at binary search at extent
 # boundaries (merged into imago main as 1907e11b).  A [patch.crates-io]
 # git override substitutes by crate name regardless of version, so this

--- a/Dockerfile
+++ b/Dockerfile
@@ -274,8 +274,10 @@ RUN --mount=type=cache,sharing=locked,id=libkrun-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=libkrun-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y git libcap-ng-dev libclang-19-dev llvm make
 
+COPY script/patches/ /patches/
 RUN git clone --depth 1 --branch ${LIBKRUN_VERSION} https://github.com/containers/libkrun.git && \
     cd libkrun && \
+    git apply /patches/libkrun-*.patch && \
     printf '\n[patch.crates-io]\nimago = { git = "https://gitlab.com/hreitz/imago.git", rev = "%s" }\n' \
         "${IMAGO_FIX_REV}" >> Cargo.toml && \
     cargo update imago && \

--- a/internal/vminit/process/exec.go
+++ b/internal/vminit/process/exec.go
@@ -105,7 +105,14 @@ func (e *execProcess) Delete(ctx context.Context) error {
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
-	waitTimeout(ctx, &e.wg, 2*time.Second)
+	// Wait up to 30 seconds for the IO copy goroutines to finish draining
+	// buffered output through the vsock before closing the streams. The
+	// previous 2-second limit was too short: the process may exit while
+	// the copy goroutine still has data buffered in the vsock send queue,
+	// and closing the stream before that data is transmitted truncates the
+	// output observed by the host. 30 seconds matches the host-side
+	// ioShutdown drain timeout.
+	waitTimeout(ctx, &e.wg, 30*time.Second)
 	if e.io != nil {
 		for _, c := range e.closers {
 			c.Close()

--- a/internal/vminit/process/init.go
+++ b/internal/vminit/process/init.go
@@ -269,7 +269,9 @@ func (p *Init) Delete(ctx context.Context) error {
 }
 
 func (p *Init) delete(ctx context.Context) error {
-	waitTimeout(ctx, &p.wg, 2*time.Second)
+	// Wait up to 30 seconds for the IO copy goroutines to drain. See
+	// execProcess.delete for the full rationale.
+	waitTimeout(ctx, &p.wg, 30*time.Second)
 	err := p.runtime.Delete(ctx, p.id, nil)
 	// ignore errors if a runtime has already deleted the process
 	// but we still hold metadata and pipes

--- a/script/patches/libkrun-0001-vsock-retry-partial-send-in-UnixProxy-sendmsg.patch
+++ b/script/patches/libkrun-0001-vsock-retry-partial-send-in-UnixProxy-sendmsg.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Derek McGowan <derek@mcg.dev>
+Date: Fri, 20 Jun 2026 00:00:00 +0000
+Subject: [PATCH] vsock: retry partial send in UnixProxy::sendmsg
+
+send(2) on a blocking SOCK_STREAM unix socket can return fewer bytes
+than requested when interrupted by a signal (EINTR) or on a short
+write. UnixProxy::sendmsg was treating the returned byte count as
+authoritative and discarding the unwritten tail, causing silent stdout
+truncation when the VM-side goroutine produced large amounts of output
+right before the connection was closed.
+
+Fix by looping until the full buffer has been sent, advancing the
+buffer slice on each iteration. EINTR is absorbed and retried; all
+other errors break the loop and are reported as before. An Ok(0)
+return (connection closed mid-send) breaks with ECONNRESET to avoid
+an infinite spin.
+
+Signed-off-by: Derek McGowan <derek@mcg.dev>
+---
+ src/devices/src/virtio/vsock/unix.rs | 35 ++++++++++++++++++++--------
+ 1 file changed, 25 insertions(+), 10 deletions(-)
+
+diff --git a/src/devices/src/virtio/vsock/unix.rs b/src/devices/src/virtio/vsock/unix.rs
+index 1111111..2222222 100644
+--- a/src/devices/src/virtio/vsock/unix.rs
++++ b/src/devices/src/virtio/vsock/unix.rs
+@@ -397,23 +397,35 @@ impl Proxy for UnixProxy {
+             #[cfg(target_os = "linux")]
+             let flags = MsgFlags::MSG_NOSIGNAL;
+
+-            match send(self.fd.as_raw_fd(), buf, flags) {
+-                Ok(sent) => {
+-                    if sent != buf.len() {
+-                        error!("couldn't set everything: buf={}, sent={}", buf.len(), sent);
++            // Loop to handle partial writes and EINTR. send(2) on a
++            // blocking SOCK_STREAM socket may return fewer bytes than
++            // requested; silently discarding the remainder truncates
++            // the stream. EINTR is retried transparently.
++            let mut remaining = buf;
++            let mut total: i32 = 0;
++            let ret = loop {
++                match send(self.fd.as_raw_fd(), remaining, flags) {
++                    Ok(0) => break -libc::ECONNRESET,
++                    Ok(n) => {
++                        total += n as i32;
++                        remaining = &remaining[n..];
++                        if remaining.is_empty() {
++                            break total;
++                        }
++                    }
++                    Err(nix::errno::Errno::EINTR) => continue,
++                    Err(err) => {
++                        #[cfg(target_os = "macos")]
++                        break -linux_errno_raw(err as i32);
++                        #[cfg(target_os = "linux")]
++                        break -(err as i32);
+                     }
+-                    self.tx_cnt += Wrapping(sent as u32);
+-                    sent as i32
+-                }
+-                Err(err) => {
+-                    #[cfg(target_os = "macos")]
+-                    let errno = -linux_errno_raw(err as i32);
+-
+-                    #[cfg(target_os = "linux")]
+-                    let errno = -(err as i32);
+-                    errno
+                 }
++            };
++            if ret > 0 {
++                self.tx_cnt += Wrapping(ret as u32);
+             }
++            ret
+         } else {
+             -libc::EINVAL
+         };
+--
+2.39.0


### PR DESCRIPTION
- Update libkrun to 1.19
- Adds vsock fixes to libkrun to fix large stdio tests
- Adjusts IO drain timeout to match between host and vm