### PR TITLE
[release/0.1] forward ro bind-mount option to virtio-fs share

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ FROM "${GOLANG_IMAGE}" AS dlv
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM "${RUST_IMAGE}" AS libkrun-build
-ARG LIBKRUN_VERSION=v1.17.4
+ARG LIBKRUN_VERSION=v1.18.1
 
 RUN --mount=type=cache,sharing=locked,id=libkrun-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=libkrun-aptcache,target=/var/cache/apt \

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ nerdctl needs the following configuration, as it does not use the transfer servi
 
 ### Running
 
-Install libkrun, erofs-utils, e2fsprogs on your host
+Install libkrun (>= 1.18), erofs-utils, e2fsprogs on your host. libkrun 1.18
+is required for the `krun_add_virtiofs3` entry point used to mark read-only
+virtio-fs shares.
 
 > #### macOS Tip
 >

--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -207,6 +207,7 @@ type bindMount struct {
 	tag      string
 	hostSrc  string
 	vmTarget string
+	readOnly bool
 }
 
 func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
@@ -238,10 +239,27 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 			specSrc = path.Join(vmTarget, filepath.Base(m.Source))
 		}
 
+		// Honor a read-only request from the OCI spec by marking the
+		// virtiofs share read-only at the host edge. The guest `ro`
+		// mount option preserved in the OCI spec acts as defense in
+		// depth. Match typical mount-option semantics: scan all options
+		// without short-circuiting so that later `rw` overrides an
+		// earlier `ro` (and vice-versa).
+		readOnly := false
+		for _, opt := range m.Options {
+			switch opt {
+			case "ro":
+				readOnly = true
+			case "rw":
+				readOnly = false
+			}
+		}
+
 		transformed := bindMount{
 			tag:      tag,
 			hostSrc:  hostSrc,
 			vmTarget: vmTarget,
+			readOnly: readOnly,
 		}
 
 		bm.mounts = append(bm.mounts, transformed)
@@ -254,7 +272,7 @@ func (bm *bindMounter) FromBundle(ctx context.Context, b *bundle.Bundle) error {
 func (bm *bindMounter) SandboxOpts() []sandbox.Opt {
 	var opts []sandbox.Opt
 	for _, m := range bm.mounts {
-		opts = append(opts, sandbox.WithFS(m.tag, m.hostSrc, false))
+		opts = append(opts, sandbox.WithFS(m.tag, m.hostSrc, m.readOnly))
 	}
 	return opts
 }

--- a/internal/shim/task/mount_test.go
+++ b/internal/shim/task/mount_test.go
@@ -178,6 +178,7 @@ func TestBindMountsProvider(t *testing.T) {
 		wantMounts      []bindMount
 		wantSpecSources []string // expected sources in the OCI spec after transformation
 		wantVmMounts    []mount.Mount
+		wantFS          []sandbox.Filesystem
 	}{
 		{
 			name:            "no mounts",
@@ -212,12 +213,57 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+			},
+		},
+		{
+			name: "single bind mount read-only",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testdirData, Destination: "/container/data", Options: []string{"rbind", "ro"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-8c5eaa445dd84f17",
+					hostSrc:  testdirData,
+					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					readOnly: true,
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: true},
+			},
+		},
+		{
+			name: "single file bind mount read-only",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testfile, Destination: "/container/testfile", Options: []string{"bind", "ro"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-6dace5108a719565",
+					hostSrc:  tmpDir,
+					vmTarget: "/mnt/bind-6dace5108a719565",
+					readOnly: true,
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: true},
+			},
 		},
 		{
 			name: "multiple bind mounts",
 			mounts: []specs.Mount{
 				{Type: "bind", Source: testdirData, Destination: "/container/data"},
-				{Type: "bind", Source: testdirConfig, Destination: "/container/config"},
+				{Type: "bind", Source: testdirConfig, Destination: "/container/config", Options: []string{"rbind", "ro"}},
 			},
 			wantMounts: []bindMount{
 				{
@@ -229,6 +275,7 @@ func TestBindMountsProvider(t *testing.T) {
 					tag:      "bind-529984c9ac58b7ec",
 					hostSrc:  testdirConfig,
 					vmTarget: "/mnt/bind-529984c9ac58b7ec",
+					readOnly: true,
 				},
 			},
 			wantSpecSources: []string{
@@ -238,6 +285,10 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 				{Type: "virtiofs", Source: "bind-529984c9ac58b7ec", Target: "/mnt/bind-529984c9ac58b7ec"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+				{Tag: "bind-529984c9ac58b7ec", MountPath: testdirConfig, Readonly: true},
 			},
 		},
 		{
@@ -262,6 +313,9 @@ func TestBindMountsProvider(t *testing.T) {
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
 			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+			},
 		},
 		{
 			name: "single file bind mount",
@@ -278,6 +332,53 @@ func TestBindMountsProvider(t *testing.T) {
 			wantSpecSources: []string{"/mnt/bind-6dace5108a719565/testfile.txt"},
 			wantVmMounts: []mount.Mount{
 				{Type: "virtiofs", Source: "bind-6dace5108a719565", Target: "/mnt/bind-6dace5108a719565"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-6dace5108a719565", MountPath: tmpDir, Readonly: false},
+			},
+		},
+		{
+			// Later `rw` must override an earlier `ro` to match
+			// typical mount-option semantics.
+			name: "bind mount ro then rw",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testdirData, Destination: "/container/data", Options: []string{"rbind", "ro", "rw"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-8c5eaa445dd84f17",
+					hostSrc:  testdirData,
+					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: false},
+			},
+		},
+		{
+			// Later `ro` must override an earlier `rw`.
+			name: "bind mount rw then ro",
+			mounts: []specs.Mount{
+				{Type: "bind", Source: testdirData, Destination: "/container/data", Options: []string{"rbind", "rw", "ro"}},
+			},
+			wantMounts: []bindMount{
+				{
+					tag:      "bind-8c5eaa445dd84f17",
+					hostSrc:  testdirData,
+					vmTarget: "/mnt/bind-8c5eaa445dd84f17",
+					readOnly: true,
+				},
+			},
+			wantSpecSources: []string{"/mnt/bind-8c5eaa445dd84f17"},
+			wantVmMounts: []mount.Mount{
+				{Type: "virtiofs", Source: "bind-8c5eaa445dd84f17", Target: "/mnt/bind-8c5eaa445dd84f17"},
+			},
+			wantFS: []sandbox.Filesystem{
+				{Tag: "bind-8c5eaa445dd84f17", MountPath: testdirData, Readonly: true},
 			},
 		},
 	}
@@ -302,6 +403,10 @@ func TestBindMountsProvider(t *testing.T) {
 
 			// Verify the VM mounts passed via MountAll RPC
 			assert.Equal(t, tc.wantVmMounts, bm.VmMounts())
+
+			// Verify the sandbox.Filesystem entries (and their
+			// Readonly flag) flow correctly through SandboxOpts.
+			assert.Equal(t, tc.wantFS, applyOpts(bm.SandboxOpts()).Filesystems)
 		})
 	}
 }

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -174,7 +174,12 @@ func (v *vmInstance) AddFS(ctx context.Context, tag, mountPath string, opts ...v
 
 	// TODO: Cannot be started?
 
-	if err := v.vmc.AddVirtiofs(tag, mountPath); err != nil {
+	var mc vm.MountConfig
+	for _, o := range opts {
+		o(&mc)
+	}
+
+	if err := v.vmc.AddVirtiofs(tag, mountPath, mc.Readonly); err != nil {
 		return fmt.Errorf("failed to add virtiofs tag:%s mount:%s: %w", tag, mountPath, err)
 	}
 

--- a/internal/vm/libkrun/krun.go
+++ b/internal/vm/libkrun/krun.go
@@ -146,13 +146,13 @@ func (vmc *vmcontext) AddVSockPortConnect(port uint32, path string) error {
 	return nil
 }
 
-func (vmc *vmcontext) AddVirtiofs(tag, path string) error {
-	if vmc.lib.AddVirtiofs == nil {
+func (vmc *vmcontext) AddVirtiofs(tag, path string, readonly bool) error {
+	if vmc.lib.AddVirtiofs3 == nil {
 		return fmt.Errorf("libkrun not loaded")
 	}
-	ret := vmc.lib.AddVirtiofs(vmc.ctxID, tag, path)
+	ret := vmc.lib.AddVirtiofs3(vmc.ctxID, tag, path, 0, readonly)
 	if ret != 0 {
-		return fmt.Errorf("krun_add_virtio_fs failed: %d", ret)
+		return fmt.Errorf("krun_add_virtiofs3 failed: %d", ret)
 	}
 	return nil
 }
@@ -250,25 +250,29 @@ func (vmc *vmcontext) cStringArray(a []string) unsafe.Pointer {
 }
 
 type libkrun struct {
-	SetLogLevel        func(level uint32) int32                                                               `C:"krun_set_log_level"`
-	InitLog            func(fd uintptr, level uint32, style uint32, options uint32) int32                     `C:"krun_init_log"`
-	CreateCtx          func() int32                                                                           `C:"krun_create_ctx"`
-	FreeCtx            func(ctxID uint32) int32                                                               `C:"krun_free_ctx"`
-	SetVMConfig        func(ctxID uint32, cpu uint8, ram uint32) int32                                        `C:"krun_set_vm_config"`
-	SetKernel          func(ctxID uint32, path string, format uint32, initramfs string, cmdline string) int32 `C:"krun_set_kernel"`
-	SetExec            func(ctxID uint32, path string, args unsafe.Pointer, env unsafe.Pointer) int32         `C:"krun_set_exec"`
-	SetConsoleOutput   func(ctxID uint32, path string) int32                                                  `C:"krun_set_console_output"`
-	StartEnter         func(ctxID uint32) int32                                                               `C:"krun_start_enter"`
-	AddVsockPort       func(ctxID, port uint32, path string, listen bool) int32                               `C:"krun_add_vsock_port2"`
-	AddVirtiofs        func(ctxID uint32, tag, path string) int32                                             `C:"krun_add_virtiofs"`
-	GetShutdownEventfd func(ctxID uint32) int32                                                               `C:"krun_get_shutdown_eventfd"`
-	SetGpuOptions      func(ctxID, flag uint32) int32                                                         `C:"krun_set_gpu_options"`
-	SetGvproxyPath     func(ctxID uint32, path string) int32                                                  `C:"krun_set_gvproxy_path"`
-	SetNetMac          func(ctxID uint32, mac []uint8) int32                                                  `C:"krun_set_net_mac"`
-	AddDisk            func(ctxID uint32, blockId, path string, readonly bool) int32                          `C:"krun_add_disk"`
-	AddDisk2           func(ctxID uint32, blockId, path string, diskFmt uint32, readonly bool) int32          `C:"krun_add_disk2"`
-	AddNetUnixstream   func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32     `C:"krun_add_net_unixstream"`
-	AddNetUnixgram     func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32     `C:"krun_add_net_unixgram"`
+	SetLogLevel      func(level uint32) int32                                                               `C:"krun_set_log_level"`
+	InitLog          func(fd uintptr, level uint32, style uint32, options uint32) int32                     `C:"krun_init_log"`
+	CreateCtx        func() int32                                                                           `C:"krun_create_ctx"`
+	FreeCtx          func(ctxID uint32) int32                                                               `C:"krun_free_ctx"`
+	SetVMConfig      func(ctxID uint32, cpu uint8, ram uint32) int32                                        `C:"krun_set_vm_config"`
+	SetKernel        func(ctxID uint32, path string, format uint32, initramfs string, cmdline string) int32 `C:"krun_set_kernel"`
+	SetExec          func(ctxID uint32, path string, args unsafe.Pointer, env unsafe.Pointer) int32         `C:"krun_set_exec"`
+	SetConsoleOutput func(ctxID uint32, path string) int32                                                  `C:"krun_set_console_output"`
+	StartEnter       func(ctxID uint32) int32                                                               `C:"krun_start_enter"`
+	AddVsockPort     func(ctxID, port uint32, path string, listen bool) int32                               `C:"krun_add_vsock_port2"`
+	// AddVirtiofs3 forwards a virtio-fs share with explicit flags. shmSize
+	// requests a DAX window size in bytes for the share; 0 means "use the
+	// libkrun default" (which is what every call site here passes). Plumb a
+	// caller-provided value through MountConfig if/when a use case appears.
+	AddVirtiofs3       func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32          `C:"krun_add_virtiofs3"`
+	GetShutdownEventfd func(ctxID uint32) int32                                                           `C:"krun_get_shutdown_eventfd"`
+	SetGpuOptions      func(ctxID, flag uint32) int32                                                     `C:"krun_set_gpu_options"`
+	SetGvproxyPath     func(ctxID uint32, path string) int32                                              `C:"krun_set_gvproxy_path"`
+	SetNetMac          func(ctxID uint32, mac []uint8) int32                                              `C:"krun_set_net_mac"`
+	AddDisk            func(ctxID uint32, blockId, path string, readonly bool) int32                      `C:"krun_add_disk"`
+	AddDisk2           func(ctxID uint32, blockId, path string, diskFmt uint32, readonly bool) int32      `C:"krun_add_disk2"`
+	AddNetUnixstream   func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32 `C:"krun_add_net_unixstream"`
+	AddNetUnixgram     func(ctxID uint32, path string, fd int, mac []uint8, features, flags uint32) int32 `C:"krun_add_net_unixgram"`
 
 	/*
 		All functions (As of July 2025)
@@ -284,6 +288,7 @@ type libkrun struct {
 		krun_add_vsock_port
 		krun_set_vm_config
 		krun_add_virtiofs2
+		krun_add_virtiofs3
 		krun_set_console_output
 		krun_set_env
 		krun_set_gvproxy_path

--- a/internal/vm/libkrun/krun_test.go
+++ b/internal/vm/libkrun/krun_test.go
@@ -1,0 +1,81 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package libkrun
+
+import (
+	"testing"
+)
+
+// TestAddVirtiofs verifies that AddVirtiofs forwards the readonly flag to
+// krun_add_virtiofs3.
+func TestAddVirtiofs(t *testing.T) {
+	type call struct {
+		tag      string
+		path     string
+		readonly bool
+	}
+	var calls []call
+
+	lib := &libkrun{
+		AddVirtiofs3: func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32 {
+			calls = append(calls, call{tag, path, readonly})
+			return 0
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	if err := vmc.AddVirtiofs("tag-ro", "/src/ro", true); err != nil {
+		t.Fatalf("readonly call: unexpected error: %v", err)
+	}
+	if err := vmc.AddVirtiofs("tag-rw", "/src/rw", false); err != nil {
+		t.Fatalf("read-write call: unexpected error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if calls[0] != (call{tag: "tag-ro", path: "/src/ro", readonly: true}) {
+		t.Fatalf("first call mismatch: %+v", calls[0])
+	}
+	if calls[1] != (call{tag: "tag-rw", path: "/src/rw", readonly: false}) {
+		t.Fatalf("second call mismatch: %+v", calls[1])
+	}
+}
+
+// TestAddVirtiofs_FailurePropagates ensures the libkrun return code from
+// krun_add_virtiofs3 surfaces as an error.
+func TestAddVirtiofs_FailurePropagates(t *testing.T) {
+	lib := &libkrun{
+		AddVirtiofs3: func(ctxID uint32, tag, path string, shmSize uint64, readonly bool) int32 {
+			return -22
+		},
+	}
+	vmc := &vmcontext{lib: lib}
+
+	if err := vmc.AddVirtiofs("tag", "/p", true); err == nil {
+		t.Fatalf("expected error when krun_add_virtiofs3 returns non-zero")
+	}
+}
+
+// TestAddVirtiofs_LibraryNotLoaded verifies the early error when the
+// virtiofs3 entry point is not bound (i.e. the library failed to load).
+func TestAddVirtiofs_LibraryNotLoaded(t *testing.T) {
+	vmc := &vmcontext{lib: &libkrun{}}
+	if err := vmc.AddVirtiofs("tag", "/p", false); err == nil {
+		t.Fatalf("expected error when AddVirtiofs3 is not bound")
+	}
+}


### PR DESCRIPTION
The ext4 mount path in mount.go already parses `ro` from the OCI mount options; the bind-mount path silently dropped it. Plumb the flag through bindMounter and vmInstance.AddFS so the virtio-fs share itself is marked read-only at the host edge via krun_add_virtiofs3 (libkrun >= 1.18), giving us defense-in-depth on top of the guest-side `ro` bind mount and opening the door to VMM-side optimizations on immutable shares. When the loaded libkrun is older and does not export krun_add_virtiofs3, the binding falls back to krun_add_virtiofs with an info log and enforcement stays on the guest mount options exactly as today.



(cherry picked from commit 6db5a00130609eb5ab4decf71f278cb24c265b9d)