### PR TITLE
Add shim log format configuration

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -31,10 +31,34 @@ import (
 	"github.com/containerd/log"
 )
 
+// SetupShimLogOption configures [SetupShimLog].
+type SetupShimLogOption func(*shimLogConfig)
+
+type format int
+
+const (
+	formatText format = iota
+	formatJSON
+)
+
+type shimLogConfig struct {
+	format format
+}
+
+// WithJSONFormat sets the log output format to emit one JSON object per line.
+func WithJSONFormat() SetupShimLogOption {
+	return func(c *shimLogConfig) {
+		c.format = formatJSON
+	}
+}
+
 // SetupShimLog configures slog-based logging for the shim process.
 // It opens the platform-specific log output (FIFO on Unix, named pipe
-// on Windows), then creates a slog TextHandler and sets it as the
-// default logger with a "component=shim" attribute.
+// on Windows), then creates a slog handler and sets it as the default
+// logger with a "component=shim" attribute.
+//
+// The handler's format defaults to text format. Pass [WithJSONFormat]
+// to emit JSON, which structured log consumers can unwrap directly.
 //
 // The base handler (without component) is stored for use by
 // [ForwardConsoleLogs] so that forwarded records carry their own
@@ -42,7 +66,12 @@ import (
 //
 // For the short-lived start and delete actions, only [log.UseSlog] is
 // called to route logrus through slog; the log output is not opened.
-func SetupShimLog() {
+func SetupShimLog(opts ...SetupShimLogOption) {
+	cfg := shimLogConfig{format: formatText}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	log.UseSlog()
 
 	var (
@@ -81,7 +110,15 @@ func SetupShimLog() {
 		log.SetLevel("debug") //nolint:errcheck
 	}
 
-	handler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: &level}).WithAttrs(attrs)
+	handlerOpts := &slog.HandlerOptions{Level: &level}
+	var handler slog.Handler
+	switch cfg.format {
+	case formatJSON:
+		handler = slog.NewJSONHandler(w, handlerOpts)
+	default:
+		handler = slog.NewTextHandler(w, handlerOpts)
+	}
+	handler = handler.WithAttrs(attrs)
 	SetBaseHandler(handler)
 	slog.SetDefault(slog.New(handler).With("component", "shim"))
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -235,6 +235,23 @@ func TestForwardConsoleLogs_DebugLevel(t *testing.T) {
 	}
 }
 
+func TestWithJSONFormat(t *testing.T) {
+	cfg := shimLogConfig{format: formatText}
+	WithJSONFormat()(&cfg)
+	if cfg.format != formatJSON {
+		t.Errorf("WithJSONFormat: got %d, want %d", cfg.format, formatJSON)
+	}
+}
+
+func TestSetupShimLogDefaultIsText(t *testing.T) {
+	// formatText must be the zero value so that a shimLogConfig without
+	// explicit initialisation defaults to text (backward-compatible).
+	var cfg shimLogConfig
+	if cfg.format != formatText {
+		t.Errorf("zero-value shimLogConfig.format = %d, want formatText (%d)", cfg.format, formatText)
+	}
+}
+
 func TestForwardJSONLog_InvalidJSON(t *testing.T) {
 	SetBaseHandler(discardHandler{})
 	if forwardJSONLog("{not json") {


### PR DESCRIPTION
### Context

I have a use-case where the shim logs (shim, vminitd, and kmesg) are being wrapped at the containerd runtime level.

i.e.

```
{"time":"2026-06-25T19:48:55.894022-05:00","level":"INFO","msg":"time=2026-06-25T19:48:55.893-05:00 level=INFO msg=\"VM connection established\" ns=docker id=eb5effb906647cb675950ac6ecd1b041309ea72ef72d92f68ac20d20f327333c component=shim t_config=117.875µs t_boot=131.007542ms t_total=131.125542ms runtime=io.containerd.nerdbox.v1"}
```

From looking into this, I believe this is because containerd writes shim logs to os.Stderr using a raw `io.Copy` (see core/runtime/v2/shim.go) instead of re-logging the shim FIFO output. For this reason, the runtime is having to capture os.Stderr and re-emit.

This change adds shim log options to enable configuration of JSON formatted logs. This will enable a workaround to parse the logs at the containerd runtime level with more simplified parsing.