### PR TITLE
Cleanup log fields and messages

### DIFF
--- a/internal/events/exchange.go
+++ b/internal/events/exchange.go
@@ -59,9 +59,9 @@ func (e *Exchange) Forward(ctx context.Context, envelope *events.Envelope) (err 
 
 	defer func() {
 		logger := log.G(ctx).WithFields(log.Fields{
-			"topic": envelope.Topic,
-			"ns":    envelope.Namespace,
-			"type":  envelope.Event.GetTypeUrl(),
+			"topic":     envelope.Topic,
+			"namespace": envelope.Namespace,
+			"type":      envelope.Event.GetTypeUrl(),
 		})
 
 		if err != nil {
@@ -97,9 +97,9 @@ func (e *Exchange) Publish(ctx context.Context, topic string, event events.Event
 
 	defer func() {
 		logger := log.G(ctx).WithFields(log.Fields{
-			"topic": envelope.Topic,
-			"ns":    envelope.Namespace,
-			"type":  envelope.Event.GetTypeUrl(),
+			"topic":     envelope.Topic,
+			"namespace": envelope.Namespace,
+			"type":      envelope.Event.GetTypeUrl(),
 		})
 
 		if err != nil {

--- a/internal/mountutil/mount.go
+++ b/internal/mountutil/mount.go
@@ -36,7 +36,7 @@ import (
 )
 
 func All(ctx context.Context, rootfs, mdir string, mounts []*types.Mount) (retErr error) {
-	log.G(ctx).WithField("mounts", mounts).Debugf("mounting rootfs components")
+	log.G(ctx).WithField("mounts", mounts).Debug("mounting rootfs components")
 	active := []mount.ActiveMount{}
 
 	// TODO: Use mount manager interface, mount temps to directory

--- a/internal/shim/task/io_copystreams_unix.go
+++ b/internal/shim/task/io_copystreams_unix.go
@@ -62,7 +62,7 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
 					if _, err := io.CopyBuffer(wc, streams[1], *p); err != nil {
-						log.G(ctx).WithError(err).WithField("stream", streams[1]).Warn("error copying stdout")
+						log.G(ctx).WithError(err).WithField("stream_id", streams[1]).Warn("error copying stdout")
 					}
 					if copying.Add(-1) == 0 {
 						close(done)

--- a/internal/shim/task/io_copystreams_windows.go
+++ b/internal/shim/task/io_copystreams_windows.go
@@ -56,7 +56,7 @@ func copyStreams(ctx context.Context, streams [3]io.ReadWriteCloser, stdin, stdo
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
 					if _, err := io.CopyBuffer(wc, streams[1], *p); err != nil {
-						log.G(ctx).WithError(err).WithField("stream", streams[1]).Warn("error copying stdout")
+						log.G(ctx).WithError(err).WithField("stream_id", streams[1]).Warn("error copying stdout")
 					}
 					if copying.Add(-1) == 0 {
 						close(done)

--- a/internal/shim/task/mount.go
+++ b/internal/shim/task/mount.go
@@ -138,7 +138,7 @@ func transformMounts(ctx context.Context, id string, ms []*types.Mount, da *disk
 				// a distinct descriptor and don't overwrite each other.
 				mergedfsPath := filepath.Join(bundleDir, fmt.Sprintf("merged_fs_%c.vmdk", letter))
 				if err := erofs.DumpVMDKDescriptorToFile(mergedfsPath, 0xfffffffe, devices); err != nil {
-					log.G(ctx).Warnf("failed to generate %v: %v", mergedfsPath, err)
+					log.G(ctx).WithError(err).WithField("path", mergedfsPath).Warn("failed to generate erofs vmdk descriptor")
 					return nil, nil, fmt.Errorf("erofs vmdk: %w", errdefs.ErrNotImplemented)
 				}
 				addDisks = append(addDisks, diskOptions{
@@ -212,7 +212,7 @@ func transformMounts(ctx context.Context, id string, ms []*types.Mount, da *disk
 					return nil, nil, fmt.Errorf("cannot use virtiofs for upper dir in overlay: %w", errdefs.ErrNotImplemented)
 				}
 			} else {
-				log.G(ctx).WithField("options", m.Options).Warnf("overlayfs missing workdir or upperdir")
+				log.G(ctx).WithField("options", m.Options).Warn("overlayfs missing workdir or upperdir")
 			}
 
 			am = append(am, m)
@@ -271,11 +271,11 @@ func finalizeErofsCandidates(ctx context.Context, id string, da *diskAllocator, 
 		gptPath := filepath.Join(bundleDir, "merged_fs_gpt.vmdk")
 		if _, err := os.Stat(gptPath); err != nil {
 			if !os.IsNotExist(err) {
-				log.G(ctx).Warnf("failed to stat %v: %v", gptPath, err)
+				log.G(ctx).WithError(err).WithField("path", gptPath).Warn("failed to stat erofs gpt vmdk descriptor")
 				return fmt.Errorf("erofs gpt vmdk: %w", errdefs.ErrNotImplemented)
 			}
 			if err := erofs.DumpGPTVMDKDescriptorToFile(gptPath, 0xfffffffe, sources); err != nil {
-				log.G(ctx).Warnf("failed to generate %v: %v", gptPath, err)
+				log.G(ctx).WithError(err).WithField("path", gptPath).Warn("failed to generate erofs gpt vmdk descriptor")
 				return fmt.Errorf("erofs gpt vmdk: %w", errdefs.ErrNotImplemented)
 			}
 		}

--- a/internal/shim/task/service.go
+++ b/internal/shim/task/service.go
@@ -283,12 +283,12 @@ func unmountAllWithRetry(ctx context.Context, mc mountAPI.TTRPCMountService) err
 // Create a new initial process and container with the underlying OCI runtime
 func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *taskAPI.CreateTaskResponse, err error) {
 	log.G(ctx).WithFields(log.Fields{
-		"id":     r.ID,
-		"bundle": r.Bundle,
-		"rootfs": r.Rootfs,
-		"stdin":  r.Stdin,
-		"stdout": r.Stdout,
-		"stderr": r.Stderr,
+		"container_id": r.ID,
+		"bundle":       r.Bundle,
+		"rootfs":       r.Rootfs,
+		"stdin":        r.Stdin,
+		"stdout":       r.Stdout,
+		"stderr":       r.Stderr,
 	}).Info("creating container task")
 
 	if r.Checkpoint != "" || r.ParentCheckpoint != "" {
@@ -388,8 +388,8 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	}
 	bootTime := time.Since(prestart)
 	log.G(ctx).WithFields(log.Fields{
-		"bootTime":     bootTime,
-		"premountTime": premountTime,
+		"t_boot":     bootTime,
+		"t_premount": premountTime,
 	}).Info("VM started")
 
 	vmc, err := s.sb.Client()
@@ -569,7 +569,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 
 // Start a process
 func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.StartResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("starting container task")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("starting container task")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -580,7 +580,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 
 // Delete the initial process and container
 func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAPI.DeleteResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("deleting task")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("deleting task")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -594,7 +594,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
 			if r.ExecID != "" {
 				if ioShutdown, ok := c.execShutdowns[r.ExecID]; ok {
 					if err := ioShutdown(ctx); err != nil {
-						log.G(ctx).WithError(err).WithField("exec", r.ExecID).Error("failed to shutdown exec io after delete")
+						log.G(ctx).WithError(err).WithField("exec_id", r.ExecID).Error("failed to shutdown exec io after delete")
 					}
 					delete(c.execShutdowns, r.ExecID)
 					delete(c.execIODone, r.ExecID)
@@ -615,7 +615,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
 
 // Exec an additional process inside the container
 func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("exec container")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("exec container")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -692,7 +692,7 @@ func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*pty
 
 // ResizePty of a process
 func (s *service) ResizePty(ctx context.Context, r *taskAPI.ResizePtyRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("resize pty")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("resize pty")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -710,17 +710,17 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (*taskAPI.
 	tc := taskAPI.NewTTRPCTaskClient(vmc)
 	st, err := tc.State(ctx, r)
 	if err != nil {
-		log.G(ctx).WithError(err).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("state")
+		log.G(ctx).WithError(err).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("state")
 		return nil, err
 	}
-	log.G(ctx).WithFields(log.Fields{"status": st.Status, "id": r.ID, "exec": r.ExecID}).Info("state")
+	log.G(ctx).WithFields(log.Fields{"status": st.Status, "container_id": r.ID, "exec_id": r.ExecID}).Info("state")
 
 	return st, err
 }
 
 // Pause the container
 func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("pause")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("pause")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -731,7 +731,7 @@ func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (*ptypes.E
 
 // Resume the container
 func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("resume")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("resume")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -742,7 +742,7 @@ func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (*ptypes
 
 // Kill a process with the provided signal
 func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("kill")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("kill")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -753,7 +753,7 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (*ptypes.Emp
 
 // Pids returns all pids inside the container
 func (s *service) Pids(ctx context.Context, r *taskAPI.PidsRequest) (*taskAPI.PidsResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("all pids")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("all pids")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -764,7 +764,7 @@ func (s *service) Pids(ctx context.Context, r *taskAPI.PidsRequest) (*taskAPI.Pi
 
 // CloseIO of a process
 func (s *service) CloseIO(ctx context.Context, r *taskAPI.CloseIORequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID, "stdin": r.Stdin}).Info("close io")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID, "stdin": r.Stdin}).Info("close io")
 	if r.Stdin {
 		// Deliver stdin EOF in-band on the stream connection rather than
 		// forwarding the RPC out-of-band. The in-band CloseWrite sends
@@ -785,8 +785,8 @@ func (s *service) CloseIO(ctx context.Context, r *taskAPI.CloseIORequest) (*ptyp
 		if stdinEOF != nil {
 			if err := stdinEOF(); err != nil {
 				log.G(ctx).WithError(err).WithFields(log.Fields{
-					"id":   r.ID,
-					"exec": r.ExecID,
+					"container_id": r.ID,
+					"exec_id":      r.ExecID,
 				}).Error("failed to send stdin EOF")
 				return nil, errgrpc.ToGRPC(err)
 			}
@@ -804,7 +804,7 @@ func (s *service) CloseIO(ctx context.Context, r *taskAPI.CloseIORequest) (*ptyp
 
 // Checkpoint the container
 func (s *service) Checkpoint(ctx context.Context, r *taskAPI.CheckpointTaskRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("checkpoint")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("checkpoint")
 	/*
 		container, err := s.getContainer(r.ID)
 		if err != nil {
@@ -819,7 +819,7 @@ func (s *service) Checkpoint(ctx context.Context, r *taskAPI.CheckpointTaskReque
 
 // Update a running container
 func (s *service) Update(ctx context.Context, r *taskAPI.UpdateTaskRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("update")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("update")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -830,7 +830,7 @@ func (s *service) Update(ctx context.Context, r *taskAPI.UpdateTaskRequest) (*pt
 
 // Wait for a process to exit
 func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (*taskAPI.WaitResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID, "exec": r.ExecID}).Info("wait")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID, "exec_id": r.ExecID}).Info("wait")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -870,8 +870,8 @@ func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (*taskAPI.Wa
 		case <-ioDone:
 		case <-drainCtx.Done():
 			log.G(ctx).WithError(drainCtx.Err()).WithFields(log.Fields{
-				"id":   r.ID,
-				"exec": r.ExecID,
+				"container_id": r.ID,
+				"exec_id":      r.ExecID,
 			}).Warn("timed out waiting for IO drain after wait")
 		}
 	}
@@ -880,7 +880,7 @@ func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (*taskAPI.Wa
 
 // Connect returns shim information such as the shim's pid
 func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (*taskAPI.ConnectResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("connect")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("connect")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
@@ -898,7 +898,7 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (*task
 }
 
 func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("shutdown")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("shutdown")
 
 	// TODO: Should we forward this to VM?
 	// tc := taskAPI.NewTTRPCTaskClient(s.vm.Client())
@@ -915,7 +915,7 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 }
 
 func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*taskAPI.StatsResponse, error) {
-	log.G(ctx).WithFields(log.Fields{"id": r.ID}).Info("stats")
+	log.G(ctx).WithFields(log.Fields{"container_id": r.ID}).Info("stats")
 	vmc, err := s.sb.Client()
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)

--- a/internal/shim/task/socketforward.go
+++ b/internal/shim/task/socketforward.go
@@ -97,7 +97,7 @@ func (p *socketForwardsProvider) FromBundle(ctx context.Context, b *bundle.Bundl
 		}
 
 		log.G(ctx).WithFields(log.Fields{
-			"id":          entry.id,
+			"forward_id":  entry.id,
 			"source":      entry.hostPath,
 			"destination": entry.containerPath,
 			"vm_path":     entry.vmPath,

--- a/internal/systools/dump.go
+++ b/internal/systools/dump.go
@@ -53,7 +53,7 @@ func DumpInfo(ctx context.Context) {
 	} else {
 		log.G(ctx).WithField("cmdline", string(b)).Debug("kernel command line")
 	}
-	log.G(ctx).WithField("ncpu", runtime.NumCPU()).Debug("Runtime info")
+	log.G(ctx).WithField("num_cpus", runtime.NumCPU()).Debug("Runtime info")
 
 	if b, err := exec.CommandContext(ctx, "/sbin/crun", "--version").Output(); err != nil {
 		log.G(ctx).WithError(err).Error("failed to get crun version")
@@ -69,11 +69,11 @@ func DumpFile(ctx context.Context, name string) {
 	}
 	b, err := os.ReadFile(name)
 	if err != nil {
-		log.G(ctx).WithError(err).WithField("f", name).Warn("failed to read file to dump")
+		log.G(ctx).WithError(err).WithField("file", name).Warn("failed to read file to dump")
 		return
 	}
 	log.G(ctx).WithFields(log.Fields{
-		"f":       name,
+		"file":    name,
 		"content": string(b),
 	}).Debug("dump file")
 }

--- a/internal/systools/proc.go
+++ b/internal/systools/proc.go
@@ -36,7 +36,7 @@ func DumpPids(ctx context.Context) {
 		return
 	}
 	if len(es) == 0 {
-		log.G(ctx).Infof("no files in /proc")
+		log.G(ctx).Info("no files in /proc")
 	}
 	for _, e := range es {
 		if _, err := strconv.Atoi(e.Name()); err == nil {
@@ -48,7 +48,7 @@ func DumpPids(ctx context.Context) {
 func dumpProcPid(ctx context.Context, pid string) {
 	f, err := os.Open(filepath.Join("/proc", pid, "status"))
 	if err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to open /proc/%s/status", pid)
+		log.G(ctx).WithError(err).WithField("pid", pid).Error("failed to open /proc status file")
 		return
 	}
 	defer f.Close()

--- a/internal/vm/libkrun/console_windows.go
+++ b/internal/vm/libkrun/console_windows.go
@@ -64,15 +64,15 @@ func connectAndCopyConsole(pipeName string, pw *io.PipeWriter) {
 			conn = c
 			break
 		}
-		log.L.WithError(err).Debugf("console pipe not ready, retrying in %s...", d)
+		log.L.WithError(err).WithField("retry_delay", d).Debug("console pipe not ready, retrying")
 		time.Sleep(d)
 	}
 	if conn == nil {
-		log.L.Warnf("failed to connect to console pipe %s within timeout", pipeName)
+		log.L.WithField("pipe", pipeName).Warn("failed to connect to console pipe within timeout")
 		return
 	}
 	defer conn.Close()
-	log.L.Debugf("connected to console pipe %s", pipeName)
+	log.L.WithField("pipe", pipeName).Debug("connected to console pipe")
 
 	if _, err := io.Copy(pw, conn); err != nil {
 		log.L.WithError(err).Debug("console pipe copy ended")

--- a/internal/vminit/ctrnetworking/ctrnetworking.go
+++ b/internal/vminit/ctrnetworking/ctrnetworking.go
@@ -92,10 +92,10 @@ func Connect(ctx context.Context, bundleDirname string, pid int) (func() error, 
 			}
 
 			log.G(ctx).WithFields(log.Fields{
-				"task":     pid,
-				"bridge":   nc.bridgeName,
-				"hostVeth": nc.hostVethName,
-				"ctrVeth":  nc.ctrVethName,
+				"task":      pid,
+				"bridge":    nc.bridgeName,
+				"host_veth": nc.hostVethName,
+				"ctr_veth":  nc.ctrVethName,
 			}).Debug("Added veth")
 			return nil
 		})

--- a/internal/vminit/process/io.go
+++ b/internal/vminit/process/io.go
@@ -155,7 +155,7 @@ func createIO(ctx context.Context, id string, ioUID, ioGID int, stdio stdio.Stdi
 		if err != nil {
 			return nil, err
 		}
-		log.G(ctx).WithField("id", id).WithField("streams", streams).Debug("using stream IO")
+		log.G(ctx).WithField("container_id", id).WithField("streams", streams).Debug("using stream IO")
 		pio.streams = streams
 		pio.copy = true
 		pio.io, err = runc.NewPipeIO(ioUID, ioGID, withConditionalIO(stdio))
@@ -225,7 +225,7 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, s
 				p := bufPool.Get().(*[]byte)
 				defer bufPool.Put(p)
 				if _, err := io.CopyBuffer(sc, src(), *p); err != nil {
-					log.G(ctx).WithError(err).Warnf("error copying %s", label)
+					log.G(ctx).WithError(err).WithField("label", label).Warn("error copying stream to vsock")
 				}
 				// CloseWrite sends OP_SHUTDOWN(SEND) ordered after all data,
 				// signalling the host to drain and deliver EOF to the FIFO.
@@ -233,7 +233,7 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, s
 				// processIO.Close() at delete time, which runs after the host
 				// has confirmed receipt (the Wait-drain gate ensures this).
 				if err := sc.CloseWrite(); err != nil {
-					log.G(ctx).WithError(err).Warnf("error closing %s stream", label)
+					log.G(ctx).WithError(err).WithField("label", label).Warn("error closing vsock stream write side")
 				}
 				wg.Done()
 			}()
@@ -276,7 +276,7 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, s
 				p := bufPool.Get().(*[]byte)
 				defer bufPool.Put(p)
 				if _, err := io.CopyBuffer(fw, src(), *p); err != nil {
-					log.G(ctx).WithError(err).Warnf("error copying %s", label)
+					log.G(ctx).WithError(err).WithField("label", label).Warn("error copying stream to fifo")
 				}
 				wg.Done()
 				fw.Close()

--- a/internal/vminit/runc/container.go
+++ b/internal/vminit/runc/container.go
@@ -94,7 +94,7 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	}
 
 	if len(r.Rootfs) != 0 && (len(r.Rootfs) != 1 || r.Rootfs[0].Type != "bind" || r.Rootfs[0].Source != rootfs) {
-		log.G(ctx).WithField("mounts", r.Rootfs).Debugf("mounting rootfs components")
+		log.G(ctx).WithField("mounts", r.Rootfs).Debug("mounting rootfs components")
 		mdir := filepath.Join(r.Bundle, "mounts")
 		if err := mountutil.All(ctx, rootfs, mdir, r.Rootfs); err != nil {
 			return nil, err
@@ -451,18 +451,18 @@ func loadProcessCgroup(ctx context.Context, pid int) (cg interface{}, err error)
 	if cgroups.Mode() == cgroups.Unified {
 		g, err := cgroupsv2.PidGroupPath(pid)
 		if err != nil {
-			log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
+			log.G(ctx).WithError(err).WithField("pid", pid).Error("failed to resolve cgroup v2 path for process")
 			return nil, err
 		}
 		cg, err = cgroupsv2.Load(g)
 		if err != nil {
-			log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
+			log.G(ctx).WithError(err).WithField("pid", pid).Error("failed to load cgroup v2 for process")
 			return nil, err
 		}
 	} else {
 		cg, err = cgroup1.Load(cgroup1.PidPath(pid))
 		if err != nil {
-			log.G(ctx).WithError(err).Errorf("loading cgroup for %d", pid)
+			log.G(ctx).WithError(err).WithField("pid", pid).Error("failed to load cgroup v1 for process")
 			return nil, err
 		}
 	}

--- a/internal/vminit/task/service.go
+++ b/internal/vminit/task/service.go
@@ -246,9 +246,9 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("id", r.ID))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("container_id", r.ID))
 
-	log.G(ctx).WithField("bundle", r.Bundle).Infof("Create task")
+	log.G(ctx).WithField("bundle", r.Bundle).Info("Create task")
 
 	s.lifecycleMu.Lock()
 	handleStarted, cleanup := s.preStart(nil)
@@ -262,7 +262,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
-	log.G(ctx).Infof("new container %s", container.ID)
+	log.G(ctx).WithField("container_id", container.ID).Info("container created")
 
 	waitForConnect, err := ctrnetworking.Connect(ctx, r.Bundle, container.Pid())
 	if err != nil {
@@ -359,9 +359,9 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 			} else {
 				if err := cg.ToggleControllers(allControllers, cgroupsv2.Enable); err != nil {
 					if userns.RunningInUserNS() {
-						log.G(ctx).WithError(err).Debugf("failed to enable controllers (%v)", allControllers)
+						log.G(ctx).WithError(err).WithField("controllers", allControllers).Debug("failed to enable cgroup controllers")
 					} else {
-						log.G(ctx).WithError(err).Errorf("failed to enable controllers (%v)", allControllers)
+						log.G(ctx).WithError(err).WithField("controllers", allControllers).Error("failed to enable cgroup controllers")
 					}
 				}
 			}
@@ -754,7 +754,7 @@ func (s *service) handleInitExit(e runcC.Exit, c *runc.Container, p *process.Ini
 	// kill all running container processes
 	if runc.ShouldKillAllOnExit(s.context, c.Bundle) {
 		if err := p.KillAll(s.context); err != nil {
-			log.G(s.context).WithError(err).WithField("id", p.ID()).
+			log.G(s.context).WithError(err).WithField("container_id", p.ID()).
 				Error("failed to kill init's children")
 		}
 	}
@@ -876,9 +876,6 @@ func (s *service) waitForCtrNetConnect(ctx context.Context, id string) error {
 
 	ts := time.Now()
 	err := wait()
-	log.G(ctx).WithFields(log.Fields{
-		"error":     err,
-		"waitedFor": time.Since(ts),
-	}).Debug("Container network connects completed")
+	log.G(ctx).WithError(err).WithField("t_wait", time.Since(ts)).Debug("Container network connects completed")
 	return err
 }

--- a/internal/vminit/vmnetworking/dhcp.go
+++ b/internal/vminit/vmnetworking/dhcp.go
@@ -67,10 +67,9 @@ func configureDHCP(ctx context.Context, iface netlink.Link, nw Network, debug bo
 	defer func() {
 		if retErr != nil {
 			if err := c.Release(l); err != nil {
-				log.G(ctx).WithFields(log.Fields{
-					"err":      err,
-					"orig_err": retErr,
-					"lease":    l.ACK.String(),
+				log.G(ctx).WithError(err).WithFields(log.Fields{
+					"cause": retErr,
+					"lease": l.ACK.String(),
 				}).Error("failed to release DHCP lease")
 			}
 		}
@@ -131,7 +130,7 @@ const defaultRenewalInterval = 86400 * time.Second // 24 hours
 func (l *DHCPLease) RenewLoop(ctx context.Context) error {
 	for {
 		interval := l.lease.ACK.IPAddressRenewalTime(defaultRenewalInterval)
-		log.G(ctx).Debugf("renewing DHCP lease in %s", interval)
+		log.G(ctx).WithField("interval", interval).Debug("renewing DHCP lease")
 
 		select {
 		case <-ctx.Done():

--- a/internal/vminit/vmnetworking/vmnetworking.go
+++ b/internal/vminit/vmnetworking/vmnetworking.go
@@ -79,10 +79,7 @@ func SetupVM(ctx context.Context, nws []Network, debug bool) (func(context.Conte
 		return nil, nil, err
 	}
 	if err := netlink.LinkSetUp(link); err != nil {
-		log.G(ctx).WithFields(log.Fields{
-			"err":   err,
-			"iface": link.Attrs().Name,
-		}).Error("failed to bring up lo interface")
+		log.G(ctx).WithError(err).WithField("iface", link.Attrs().Name).Error("failed to bring up lo interface")
 		return nil, nil, err
 	}
 	log.G(ctx).Debug("brought up lo interface")
@@ -225,8 +222,7 @@ func configureStatic(ctx context.Context, iface netlink.Link, nw Network) error 
 			// network.
 			Flags: unix.IFA_F_PERMANENT | unix.IFA_F_NODAD,
 		}); err != nil {
-			log.G(ctx).WithFields(log.Fields{
-				"error": err,
+			log.G(ctx).WithError(err).WithFields(log.Fields{
 				"addr":  prefix.String(),
 				"iface": iface.Attrs().Name,
 			}).Error("failed to add IP address to virtio interface")

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -62,13 +62,13 @@ func SetupShimLog() {
 			if i+1 < len(args) {
 				i++
 				ns = args[i]
-				attrs = append(attrs, slog.String("ns", ns))
+				attrs = append(attrs, slog.String("namespace", ns))
 			}
 		case "-id":
 			if i+1 < len(args) {
 				i++
 				id = args[i]
-				attrs = append(attrs, slog.String("id", id))
+				attrs = append(attrs, slog.String("container_id", id))
 			}
 		}
 	}

--- a/pkg/vminit/initd/initd.go
+++ b/pkg/vminit/initd/initd.go
@@ -151,7 +151,7 @@ func Run(ctx context.Context) error {
 		return err
 	}
 
-	log.G(ctx).WithField("t", time.Since(t1)).Debug("initialized vminitd")
+	log.G(ctx).WithField("t_init", time.Since(t1)).Debug("initialized vminitd")
 
 	runtime.GOMAXPROCS(2)
 
@@ -350,7 +350,7 @@ func newService(ctx context.Context, config Config, shutdownSvc shutdown.Service
 		instance, err := p.Instance()
 		if err != nil {
 			if plugin.IsSkipPlugin(err) {
-				log.G(ctx).WithFields(log.Fields{"error": err, "plugin_id": id}).Info("skip loading plugin")
+				log.G(ctx).WithError(err).WithField("plugin_id", id).Info("skip loading plugin")
 				continue
 			}
 

--- a/plugins/services/bundle/service.go
+++ b/plugins/services/bundle/service.go
@@ -66,7 +66,7 @@ func (s *service) Create(ctx context.Context, r *api.CreateRequest) (*api.Create
 	if err := os.Mkdir(d, 0755); err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
-	log.G(ctx).Infof("Creating bundle at %s", d)
+	log.G(ctx).WithField("path", d).Info("creating bundle")
 	if err := os.Mkdir(filepath.Join(d, "rootfs"), 0755); err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}

--- a/plugins/services/transfer/service.go
+++ b/plugins/services/transfer/service.go
@@ -18,6 +18,7 @@ package transfer
 
 import (
 	"context"
+	"fmt"
 
 	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	"github.com/containerd/containerd/v2/core/streaming"
@@ -95,7 +96,7 @@ func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest
 		} else if !errdefs.IsNotImplemented(err) {
 			return nil, err
 		}
-		log.G(ctx).WithError(err).Debugf("transfer not implemented for %T to %T", src, dst)
+		log.G(ctx).WithError(err).WithField("src_type", fmt.Sprintf("%T", src)).WithField("dst_type", fmt.Sprintf("%T", dst)).Debug("transfer not implemented for type pair")
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method Transfer not implemented for %s to %s", req.Source.GetTypeUrl(), req.Destination.GetTypeUrl())
 }

--- a/plugins/shim/streaming/plugin.go
+++ b/plugins/shim/streaming/plugin.go
@@ -81,7 +81,7 @@ func (s *service) Stream(ctx context.Context, srv streamapi.TTRPCStreaming_Strea
 		return err
 	}
 
-	log.G(ctx).WithField("stream", i.ID).Debug("creating stream bridge")
+	log.G(ctx).WithField("stream_id", i.ID).Debug("creating stream bridge")
 
 	// Create a stream connection to the VM, passing through the stream ID
 	vmConn, err := s.sb.StartStream(ctx, i.ID)
@@ -90,7 +90,7 @@ func (s *service) Stream(ctx context.Context, srv streamapi.TTRPCStreaming_Strea
 	}
 	defer vmConn.Close()
 
-	log.G(ctx).WithField("stream", i.ID).Debug("stream bridge established")
+	log.G(ctx).WithField("stream_id", i.ID).Debug("stream bridge established")
 
 	// Send ack back to containerd client
 	e, _ := typeurl.MarshalAnyToProto(&ptypes.Empty{})
@@ -115,10 +115,10 @@ func (s *service) Stream(ctx context.Context, srv streamapi.TTRPCStreaming_Strea
 		// io.EOF filter on the bridge log below, leaving the VM
 		// hanging while waiting for the marker.
 		if eofErr := binary.Write(vmConn, binary.BigEndian, uint32(0)); eofErr != nil {
-			log.G(ctx).WithError(eofErr).WithField("stream", i.ID).Debug("failed to write EOF marker to vm")
+			log.G(ctx).WithError(eofErr).WithField("stream_id", i.ID).Debug("failed to write EOF marker to vm")
 		}
 		if err != nil && !errors.Is(err, io.EOF) {
-			log.G(ctx).WithError(err).WithField("stream", i.ID).Debug("client->server bridge ended")
+			log.G(ctx).WithError(err).WithField("stream_id", i.ID).Debug("client->server bridge ended")
 		}
 	}()
 
@@ -145,7 +145,7 @@ func (s *service) Stream(ctx context.Context, srv streamapi.TTRPCStreaming_Strea
 	select {
 	case err := <-v2t:
 		if err != nil && !errors.Is(err, io.EOF) {
-			log.G(ctx).WithError(err).WithField("stream", i.ID).Debug("server->client bridge ended")
+			log.G(ctx).WithError(err).WithField("stream_id", i.ID).Debug("server->client bridge ended")
 		}
 	case <-ctx.Done():
 	}

--- a/plugins/vminit/streaming/plugin.go
+++ b/plugins/vminit/streaming/plugin.go
@@ -139,7 +139,7 @@ func (s *service) Run() {
 		s.mu.Lock()
 		if _, ok := s.streams[streamID]; ok {
 			s.mu.Unlock()
-			log.L.WithField("stream", streamID).Debug("duplicate stream ID, rejecting")
+			log.L.WithField("stream_id", streamID).Debug("duplicate stream ID, rejecting")
 			// Send back an error message so the client gets a meaningful rejection
 			errMsg := fmt.Sprintf("stream %q already exists", streamID)
 			writeString(conn, errMsg)


### PR DESCRIPTION
Use consistent fields across the logs.
Update messages to be more descriptive, terse, and without formatting.