### PR TITLE
Promote Kern from nerdbox reviewer to committer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,11 +5,11 @@
 # COMMITTERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "akerouanton","Albin Kerouanton","albinker@gmail.com",""
+"Kern--","Kern Walster","kern.walster@gmail.com",""
 
 # REVIEWERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "robmry","Rob Murray","rob.murray@docker.com",""
-"Kern--","Kern Walster","kern.walster@gmail.com",""
 
 # As a containerd sub-project, containerd maintainers are also included from https://github.com/containerd/project/blob/main/MAINTAINERS.
 # Below are the containerd maintainers who contribute to nerdbox and copied here for ease of reference.


### PR DESCRIPTION
Kern has been helping out and reviewing quite a bit with Nerdbox lately. Kern has a strong background in this part of the stack and good judgment to help get code merged more quickly.