### PR TITLE
fix(transfer): honor bind-mount semantics in filesystem transfers

### DIFF
--- a/internal/transfer/containerfs.go
+++ b/internal/transfer/containerfs.go
@@ -60,7 +60,9 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 		}
 		w := d.Writer(ctx)
 		defer w.Close()
-		return writePath(root, src, w, d.MediaType, s.NoWalk)
+		// The archive's top-level name reflects the container's view of
+		// the path: a mount source's basename need not match it.
+		return writePath(root, src, path.Base(rootRel(s.Path)), w, d.MediaType, s.NoWalk)
 
 	case *ReadStream:
 		// Copy-to: ReadStream -> ContainerPath
@@ -96,6 +98,18 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // resolves against the innermost one. A bundle with no readable or parseable
 // config.json resolves to the rootfs: absent mount information there is
 // nothing to redirect, and the caller reports any genuine failure.
+//
+// A relative source is interpreted against the bundle directory, as the
+// runtime does (nerdbox itself declares such mounts for bundle extra files
+// like resolv.conf). A source that is not a directory — a single-file bind
+// mount — cannot anchor an *os.Root, so it resolves to the file's parent
+// directory with the file's name as the relative path.
+//
+// Known limitations, tracked by issue #164: a path whose subtree contains a
+// mount deeper inside (e.g. archiving /etc when /etc/resolv.conf is a mount)
+// resolves to the outer directory only, and non-bind mounts (tmpfs, ...)
+// exist only in the container's mount namespace and cannot be resolved from
+// the bundle at all.
 func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel string, err error) {
 	rootfs := filepath.Join(bundleContainerDir, "rootfs")
 
@@ -137,7 +151,23 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 		return rootfs, containerPath, nil
 	}
 
+	// This code runs in the Linux VM, where the two predicates agree;
+	// accepting either form of absolute path keeps the unit tests, which
+	// mix spec-style Linux sources with host temp directories, portable
+	// to Windows hosts.
+	if !filepath.IsAbs(bestSrc) && !path.IsAbs(bestSrc) {
+		bestSrc = filepath.Join(bundleContainerDir, bestSrc)
+	}
+
 	rel = strings.TrimPrefix(target, bestDest)
+
+	if fi, err := os.Stat(bestSrc); err == nil && !fi.IsDir() {
+		// Single-file mount: anchor at the parent directory. A residual
+		// rel below the file yields a path that fails with ENOTDIR when
+		// the caller stats it, which is the honest answer.
+		return filepath.Dir(bestSrc), filepath.Base(bestSrc) + rel, nil
+	}
+
 	if rel == "" {
 		rel = "."
 	}
@@ -159,14 +189,17 @@ func rootRel(p string) string {
 }
 
 // writePath creates a tar archive from the given path within rootfs
-// and writes it to w. When noWalk is true and path is a directory,
-// only the directory entry itself is included without walking into
-// it.
+// and writes it to w. name is the archive's top-level entry name,
+// taken from the container's view of the path: when src resolved
+// through a mount, the backing file or directory's own basename may
+// differ from the name the container sees. When noWalk is true and
+// path is a directory, only the directory entry itself is included
+// without walking into it.
 //
 // All filesystem accesses are anchored to rootfs through *os.Root,
 // so symlink resolution cannot escape the rootfs even if the
 // container concurrently mutates its own filesystem.
-func writePath(rootfs, src string, w io.Writer, mediaType string, noWalk bool) error {
+func writePath(rootfs, src, name string, w io.Writer, mediaType string, noWalk bool) error {
 	if mediaType != mediaTypeTar {
 		return fmt.Errorf("unsupported media type %q: %w", mediaType, errdefs.ErrNotImplemented)
 	}
@@ -184,12 +217,11 @@ func writePath(rootfs, src string, w io.Writer, mediaType string, noWalk bool) e
 		return fmt.Errorf("failed to stat %s: %w", src, err)
 	}
 
-	// The top-level entry name is the basename of the requested
-	// path. When the caller asks for the whole filesystem (path "/"),
-	// relPath is "." and baseName is "."; child entries then drop
-	// the leading "./" via path.Join, so the tar contains
-	// "bin/sh" rather than leaking the host bundle's directory name.
-	baseName := path.Base(relPath)
+	// When the caller asks for the whole filesystem (path "/"), name
+	// is "."; child entries then drop the leading "./" via path.Join,
+	// so the tar contains "bin/sh" rather than leaking the host
+	// bundle's directory name.
+	baseName := name
 
 	tw := tar.NewWriter(w)
 
@@ -303,6 +335,13 @@ func readPath(r io.Reader, rootfs, dstPath, mediaType string, preserveOwnership 
 
 	dst := root
 	if relDst != "." {
+		// A destination naming an existing non-directory — a plain
+		// file in the rootfs, or the source of a single-file bind
+		// mount after resolution — receives the archived file's bytes
+		// rather than a tree extraction.
+		if fi, err := root.Stat(relDst); err == nil && !fi.IsDir() {
+			return extractOverFile(root, relDst, r, preserveOwnership)
+		}
 		if err := root.MkdirAll(relDst, 0755); err != nil {
 			return fmt.Errorf("failed to create destination: %w", err)
 		}
@@ -336,6 +375,55 @@ func readPath(r io.Reader, rootfs, dstPath, mediaType string, preserveOwnership 
 		if err := extractTarEntry(dst, entryName, header, tr, preserveOwnership); err != nil {
 			return err
 		}
+	}
+}
+
+// extractOverFile extracts an archive onto a destination that is an
+// existing file rather than a directory, replacing its contents with
+// the archived bytes. Only an archive carrying a single regular file
+// makes sense here; a directory or any other entry type cannot be
+// extracted over a file and is rejected. The file is truncated in
+// place rather than recreated, so it keeps its mode and, when it is a
+// bind-mount source, its inode — a mounted file replaced by a new
+// inode would leave the container reading the stale one.
+func extractOverFile(dst *os.Root, target string, r io.Reader, preserveOwnership bool) error {
+	tr := tar.NewReader(r)
+	written := false
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar header: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			return fmt.Errorf("cannot extract %q over file %s: not a regular file", header.Name, target)
+		}
+		if written {
+			return fmt.Errorf("cannot extract multiple entries over file %s", target)
+		}
+
+		f, err := dst.OpenFile(target, os.O_WRONLY|os.O_TRUNC, 0)
+		if err != nil {
+			return err
+		}
+		// Copy exactly the size the header declares; the tar reader
+		// bounds the entry anyway, and the explicit limit satisfies
+		// gosec's decompression-bomb rule (G110).
+		if _, err := io.CopyN(f, tr, header.Size); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		if preserveOwnership {
+			if err := dst.Lchown(target, header.Uid, header.Gid); err != nil {
+				return fmt.Errorf("failed to chown %s: %w", target, err)
+			}
+		}
+		written = true
 	}
 }
 

--- a/internal/transfer/containerfs.go
+++ b/internal/transfer/containerfs.go
@@ -54,7 +54,7 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 			return errdefs.ErrNotImplemented
 		}
 		bundle := filepath.Join(t.bundleDir, s.ContainerID)
-		root, src, err := resolveMountRoot(bundle, s.Path)
+		root, src, _, err := resolveMountRoot(bundle, s.Path)
 		if err != nil {
 			return err
 		}
@@ -71,9 +71,12 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 			return errdefs.ErrNotImplemented
 		}
 		bundle := filepath.Join(t.bundleDir, d.ContainerID)
-		root, dst, err := resolveMountRoot(bundle, d.Path)
+		root, dst, readonly, err := resolveMountRoot(bundle, d.Path)
 		if err != nil {
 			return err
+		}
+		if readonly {
+			return fmt.Errorf("container path %q is marked read-only: %w", d.Path, errdefs.ErrPermissionDenied)
 		}
 		r := s.Reader(ctx)
 		return readPath(r, root, dst, s.MediaType, d.PreserveOwnership)
@@ -105,36 +108,48 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // mount — cannot anchor an *os.Root, so it resolves to the file's parent
 // directory with the file's name as the relative path.
 //
+// The returned readonly flag reports that the container's view of the path is
+// write-protected: the matched mount carries a read-only option, or no mount
+// covers the path and the spec declares the root filesystem read-only.
+// Resolution operates on the backing directory, outside the mount namespace
+// where MS_RDONLY is enforced, so a writer must honor the flag rather than
+// rely on the write failing.
+//
 // Known limitations, tracked by issue #164: a path whose subtree contains a
 // mount deeper inside (e.g. archiving /etc when /etc/resolv.conf is a mount)
 // resolves to the outer directory only, and non-bind mounts (tmpfs, ...)
 // exist only in the container's mount namespace and cannot be resolved from
 // the bundle at all.
-func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel string, err error) {
+func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel string, readonly bool, err error) {
 	rootfs := filepath.Join(bundleContainerDir, "rootfs")
 
 	data, err := os.ReadFile(filepath.Join(bundleContainerDir, "config.json"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return rootfs, containerPath, nil
+			return rootfs, containerPath, false, nil
 		}
-		return "", "", fmt.Errorf("failed to read bundle config: %w", err)
+		return "", "", false, fmt.Errorf("failed to read bundle config: %w", err)
 	}
 
 	var spec struct {
+		Root struct {
+			Readonly bool `json:"readonly"`
+		} `json:"root"`
 		Mounts []struct {
-			Destination string `json:"destination"`
-			Type        string `json:"type"`
-			Source      string `json:"source"`
+			Destination string   `json:"destination"`
+			Type        string   `json:"type"`
+			Source      string   `json:"source"`
+			Options     []string `json:"options"`
 		} `json:"mounts"`
 	}
 	if err := json.Unmarshal(data, &spec); err != nil {
-		return rootfs, containerPath, nil
+		return rootfs, containerPath, false, nil
 	}
 
 	target := path.Clean("/" + containerPath)
 
 	var bestDest, bestSrc string
+	var bestReadonly bool
 	for _, m := range spec.Mounts {
 		if m.Type != "bind" || m.Source == "" {
 			continue
@@ -145,10 +160,11 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 		}
 		if len(dest) > len(bestDest) {
 			bestDest, bestSrc = dest, m.Source
+			bestReadonly = readOnlyMount(m.Options)
 		}
 	}
 	if bestDest == "" {
-		return rootfs, containerPath, nil
+		return rootfs, containerPath, spec.Root.Readonly, nil
 	}
 
 	// This code runs in the Linux VM, where the two predicates agree;
@@ -165,13 +181,30 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 		// Single-file mount: anchor at the parent directory. A residual
 		// rel below the file yields a path that fails with ENOTDIR when
 		// the caller stats it, which is the honest answer.
-		return filepath.Dir(bestSrc), filepath.Base(bestSrc) + rel, nil
+		return filepath.Dir(bestSrc), filepath.Base(bestSrc) + rel, bestReadonly, nil
 	}
 
 	if rel == "" {
 		rel = "."
 	}
-	return bestSrc, rel, nil
+	return bestSrc, rel, bestReadonly, nil
+}
+
+// readOnlyMount reports whether the option list marks a mount read-only.
+// All options are scanned without short-circuiting so a later "rw"
+// overrides an earlier "ro" and vice versa, matching typical
+// mount-option semantics.
+func readOnlyMount(options []string) bool {
+	readonly := false
+	for _, opt := range options {
+		switch opt {
+		case "ro":
+			readonly = true
+		case "rw":
+			readonly = false
+		}
+	}
+	return readonly
 }
 
 // rootRel converts a path expressed in the container's view (which

--- a/internal/transfer/containerfs.go
+++ b/internal/transfer/containerfs.go
@@ -19,6 +19,8 @@ package transfer
 import (
 	"archive/tar"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -51,10 +53,14 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 		if !ok {
 			return errdefs.ErrNotImplemented
 		}
-		rootfs := filepath.Join(t.bundleDir, s.ContainerID, "rootfs")
+		bundle := filepath.Join(t.bundleDir, s.ContainerID)
+		root, src, err := resolveMountRoot(bundle, s.Path)
+		if err != nil {
+			return err
+		}
 		w := d.Writer(ctx)
 		defer w.Close()
-		return writePath(rootfs, s.Path, w, d.MediaType, s.NoWalk)
+		return writePath(root, src, w, d.MediaType, s.NoWalk)
 
 	case *ReadStream:
 		// Copy-to: ReadStream -> ContainerPath
@@ -62,12 +68,80 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 		if !ok {
 			return errdefs.ErrNotImplemented
 		}
-		rootfs := filepath.Join(t.bundleDir, d.ContainerID, "rootfs")
+		bundle := filepath.Join(t.bundleDir, d.ContainerID)
+		root, dst, err := resolveMountRoot(bundle, d.Path)
+		if err != nil {
+			return err
+		}
 		r := s.Reader(ctx)
-		return readPath(r, rootfs, d.Path, s.MediaType, d.PreserveOwnership)
+		return readPath(r, root, dst, s.MediaType, d.PreserveOwnership)
 	}
 
 	return errdefs.ErrNotImplemented
+}
+
+// resolveMountRoot maps a path expressed in the container's view onto the
+// directory that backs it, returning that directory and the path relative to
+// it.
+//
+// The bundle's rootfs backs only the paths no mount covers. Where the runtime
+// spec declares a bind mount, the container's mount namespace has the source
+// mounted over the destination, so the rootfs entry underneath is shadowed:
+// extracting there produces a file the container never sees, and archiving
+// from there reads whatever the rootfs happens to hold rather than the mounted
+// content. Resolving against the mount's source keeps both directions
+// consistent with the container's own view of its filesystem.
+//
+// The longest matching destination wins, so a mount nested inside another
+// resolves against the innermost one. A bundle with no readable or parseable
+// config.json resolves to the rootfs: absent mount information there is
+// nothing to redirect, and the caller reports any genuine failure.
+func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel string, err error) {
+	rootfs := filepath.Join(bundleContainerDir, "rootfs")
+
+	data, err := os.ReadFile(filepath.Join(bundleContainerDir, "config.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return rootfs, containerPath, nil
+		}
+		return "", "", fmt.Errorf("failed to read bundle config: %w", err)
+	}
+
+	var spec struct {
+		Mounts []struct {
+			Destination string `json:"destination"`
+			Type        string `json:"type"`
+			Source      string `json:"source"`
+		} `json:"mounts"`
+	}
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return rootfs, containerPath, nil
+	}
+
+	target := path.Clean("/" + containerPath)
+
+	var bestDest, bestSrc string
+	for _, m := range spec.Mounts {
+		if m.Type != "bind" || m.Source == "" {
+			continue
+		}
+		dest := path.Clean("/" + m.Destination)
+		if target != dest && !strings.HasPrefix(target, strings.TrimSuffix(dest, "/")+"/") {
+			continue
+		}
+		if len(dest) > len(bestDest) {
+			bestDest, bestSrc = dest, m.Source
+		}
+	}
+	if bestDest == "" {
+		return rootfs, containerPath, nil
+	}
+
+	rel = strings.TrimPrefix(target, bestDest)
+	if rel == "" {
+		rel = "."
+	}
+	return bestSrc, rel, nil
 }
 
 // rootRel converts a path expressed in the container's view (which

--- a/internal/transfer/containerfs.go
+++ b/internal/transfer/containerfs.go
@@ -98,9 +98,9 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // consistent with the container's own view of its filesystem.
 //
 // The longest matching destination wins, so a mount nested inside another
-// resolves against the innermost one. A bundle with no readable or parseable
-// config.json resolves to the rootfs: absent mount information there is
-// nothing to redirect, and the caller reports any genuine failure.
+// resolves against the innermost one. A bundle with no config.json, or one
+// that does not parse as a spec, resolves to the rootfs; a config that
+// exists but cannot be read is an error rather than a blind fallback.
 //
 // A relative source is interpreted against the bundle directory, as the
 // runtime does (nerdbox itself declares such mounts for bundle extra files
@@ -108,12 +108,8 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // mount — cannot anchor an *os.Root, so it resolves to the file's parent
 // directory with the file's name as the relative path.
 //
-// The returned readonly flag reports that the container's view of the path is
-// write-protected: the matched mount carries a read-only option, or no mount
-// covers the path and the spec declares the root filesystem read-only.
-// Resolution operates on the backing directory, outside the mount namespace
-// where MS_RDONLY is enforced, so a writer must honor the flag rather than
-// rely on the write failing.
+// Writers must honor the readonly result: resolution bypasses the mount
+// namespace, so MS_RDONLY never intervenes on the backing directory.
 //
 // Known limitations, tracked by issue #164: a path whose subtree contains a
 // mount deeper inside (e.g. archiving /etc when /etc/resolv.conf is a mount)
@@ -190,10 +186,7 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 	return bestSrc, rel, bestReadonly, nil
 }
 
-// readOnlyMount reports whether the option list marks a mount read-only.
-// All options are scanned without short-circuiting so a later "rw"
-// overrides an earlier "ro" and vice versa, matching typical
-// mount-option semantics.
+// readOnlyMount applies mount(8) semantics: the last "ro" or "rw" wins.
 func readOnlyMount(options []string) bool {
 	readonly := false
 	for _, opt := range options {
@@ -221,25 +214,25 @@ func rootRel(p string) string {
 	return p
 }
 
-// writePath creates a tar archive from the given path within rootfs
-// and writes it to w. name is the archive's top-level entry name,
-// taken from the container's view of the path: when src resolved
-// through a mount, the backing file or directory's own basename may
-// differ from the name the container sees. When noWalk is true and
-// path is a directory, only the directory entry itself is included
-// without walking into it.
+// writePath creates a tar archive from the given path within dir — the
+// resolved backing directory, a rootfs or a mount source — and writes it
+// to w. name is the archive's top-level entry name, taken from the
+// container's view of the path: when src resolved through a mount, the
+// backing file or directory's own basename may differ from the name the
+// container sees. When noWalk is true and path is a directory, only the
+// directory entry itself is included without walking into it.
 //
-// All filesystem accesses are anchored to rootfs through *os.Root,
-// so symlink resolution cannot escape the rootfs even if the
-// container concurrently mutates its own filesystem.
-func writePath(rootfs, src, name string, w io.Writer, mediaType string, noWalk bool) error {
+// All filesystem accesses are anchored to dir through *os.Root, so
+// symlink resolution cannot escape it even if the container
+// concurrently mutates its own filesystem.
+func writePath(dir, src, name string, w io.Writer, mediaType string, noWalk bool) error {
 	if mediaType != mediaTypeTar {
 		return fmt.Errorf("unsupported media type %q: %w", mediaType, errdefs.ErrNotImplemented)
 	}
 
-	root, err := os.OpenRoot(rootfs)
+	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return fmt.Errorf("failed to open rootfs: %w", err)
+		return fmt.Errorf("failed to open transfer root: %w", err)
 	}
 	defer root.Close()
 
@@ -286,8 +279,8 @@ func writePath(rootfs, src, name string, w io.Writer, mediaType string, noWalk b
 			// The root entry itself.
 			rel = ""
 		case relPath == ".":
-			// Walking from the rootfs root: walkPath is already the
-			// entry name relative to the root.
+			// Walking from the root itself: walkPath is already the
+			// entry name relative to it.
 			rel = walkPath
 		default:
 			// Walking a subdirectory: strip "relPath/" prefix.
@@ -309,7 +302,7 @@ func writePath(rootfs, src, name string, w io.Writer, mediaType string, noWalk b
 }
 
 // writeTarEntry writes a single tar entry. srcPath is interpreted
-// relative to root, so symlink resolution cannot escape the rootfs.
+// relative to root, so symlink resolution cannot escape it.
 func writeTarEntry(root *os.Root, tw *tar.Writer, srcPath string, fi os.FileInfo, name string) error {
 	header, err := tar.FileInfoHeader(fi, "")
 	if err != nil {
@@ -344,23 +337,24 @@ func writeTarEntry(root *os.Root, tw *tar.Writer, srcPath string, fi os.FileInfo
 }
 
 // readPath reads a tar archive from r and extracts it under path
-// within rootfs. When preserveOwnership is true, extracted files have
-// their UID/GID set from the tar headers.
+// within dir — the resolved backing directory, a rootfs or a mount
+// source. When preserveOwnership is true, extracted files have their
+// UID/GID set from the tar headers.
 //
 // The destination directory is opened as a sub-*os.Root so the
 // destination boundary is enforced by os.Root rather than by lexical
-// path checks. Pre-existing symlinks within the rootfs, symlinks
-// created by earlier entries in the same archive, absolute symlink
-// targets, and tar entry names containing "../" all resolve within
-// the destination's sub-root and cannot redirect writes outside it.
-func readPath(r io.Reader, rootfs, dstPath, mediaType string, preserveOwnership bool) error {
+// path checks. Pre-existing symlinks within dir, symlinks created by
+// earlier entries in the same archive, absolute symlink targets, and
+// tar entry names containing "../" all resolve within the
+// destination's sub-root and cannot redirect writes outside it.
+func readPath(r io.Reader, dir, dstPath, mediaType string, preserveOwnership bool) error {
 	if mediaType != mediaTypeTar {
 		return fmt.Errorf("unsupported media type %q: %w", mediaType, errdefs.ErrNotImplemented)
 	}
 
-	root, err := os.OpenRoot(rootfs)
+	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return fmt.Errorf("failed to open rootfs: %w", err)
+		return fmt.Errorf("failed to open transfer root: %w", err)
 	}
 	defer root.Close()
 
@@ -411,53 +405,68 @@ func readPath(r io.Reader, rootfs, dstPath, mediaType string, preserveOwnership 
 	}
 }
 
-// extractOverFile extracts an archive onto a destination that is an
-// existing file rather than a directory, replacing its contents with
-// the archived bytes. Only an archive carrying a single regular file
-// makes sense here; a directory or any other entry type cannot be
-// extracted over a file and is rejected. The file is truncated in
-// place rather than recreated, so it keeps its mode and, when it is a
-// bind-mount source, its inode — a mounted file replaced by a new
-// inode would leave the container reading the stale one.
+// extractOverFile extracts an archive of exactly one regular file over an
+// existing file. The payload is staged first so a rejected archive leaves
+// the file untouched; truncating in place keeps a bind-mount source's inode.
 func extractOverFile(dst *os.Root, target string, r io.Reader, preserveOwnership bool) error {
 	tr := tar.NewReader(r)
-	written := false
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read tar header: %w", err)
-		}
-		if header.Typeflag != tar.TypeReg {
-			return fmt.Errorf("cannot extract %q over file %s: not a regular file", header.Name, target)
-		}
-		if written {
-			return fmt.Errorf("cannot extract multiple entries over file %s", target)
-		}
-
-		f, err := dst.OpenFile(target, os.O_WRONLY|os.O_TRUNC, 0)
-		if err != nil {
-			return err
-		}
-		// Copy exactly the size the header declares; the tar reader
-		// bounds the entry anyway, and the explicit limit satisfies
-		// gosec's decompression-bomb rule (G110).
-		if _, err := io.CopyN(f, tr, header.Size); err != nil {
-			f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-		if preserveOwnership {
-			if err := dst.Lchown(target, header.Uid, header.Gid); err != nil {
-				return fmt.Errorf("failed to chown %s: %w", target, err)
-			}
-		}
-		written = true
+	header, err := tr.Next()
+	if err == io.EOF {
+		return fmt.Errorf("cannot extract empty archive over file %s", target)
 	}
+	if err != nil {
+		return fmt.Errorf("failed to read tar header: %w", err)
+	}
+	if header.Typeflag != tar.TypeReg {
+		return fmt.Errorf("cannot extract %q over file %s: not a regular file", header.Name, target)
+	}
+
+	// A fixed name overwrites debris from an interrupted transfer.
+	tmp := target + ".transfer-tmp"
+	f, err := dst.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to stage %s: %w", target, err)
+	}
+	defer dst.Remove(tmp)
+	// Copy exactly the size the header declares; the tar reader
+	// bounds the entry anyway, and the explicit limit satisfies
+	// gosec's decompression-bomb rule (G110).
+	if _, err := io.CopyN(f, tr, header.Size); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	switch _, err := tr.Next(); {
+	case err == nil:
+		return fmt.Errorf("cannot extract multiple entries over file %s", target)
+	case err != io.EOF:
+		return fmt.Errorf("failed to read tar header: %w", err)
+	}
+
+	staged, err := dst.Open(tmp)
+	if err != nil {
+		return err
+	}
+	defer staged.Close()
+	out, err := dst.OpenFile(target, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, staged); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if preserveOwnership {
+		if err := dst.Lchown(target, header.Uid, header.Gid); err != nil {
+			return fmt.Errorf("failed to chown %s: %w", target, err)
+		}
+	}
+	return nil
 }
 
 func extractTarEntry(dst *os.Root, target string, header *tar.Header, r io.Reader, preserveOwnership bool) error {

--- a/internal/transfer/containerfs.go
+++ b/internal/transfer/containerfs.go
@@ -19,6 +19,7 @@ package transfer
 import (
 	"archive/tar"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,8 +87,9 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 }
 
 // resolveMountRoot maps a path expressed in the container's view onto the
-// directory that backs it, returning that directory and the path relative to
-// it.
+// directory that backs it, returning that directory and the path within it.
+// The returned path may retain a leading slash; callers normalize it with
+// rootRel before passing it to an *os.Root operation.
 //
 // The bundle's rootfs backs only the paths no mount covers. Where the runtime
 // spec declares a bind mount, the container's mount namespace has the source
@@ -97,16 +99,18 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // content. Resolving against the mount's source keeps both directions
 // consistent with the container's own view of its filesystem.
 //
-// The longest matching destination wins, so a mount nested inside another
-// resolves against the innermost one. A bundle with no config.json, or one
-// that does not parse as a spec, resolves to the rootfs; a config that
-// exists but cannot be read is an error rather than a blind fallback.
+// Mounts are applied in spec order, so the last matching bind mount wins. A
+// later parent mount can therefore hide an earlier child mount. Legacy relative
+// destinations are interpreted from "/", as required by the Linux OCI runtime
+// spec. A bundle with no config.json resolves to the rootfs; a config that
+// exists but cannot be read or parsed is an error rather than a blind fallback.
 //
 // A relative source is interpreted against the bundle directory, as the
 // runtime does (nerdbox itself declares such mounts for bundle extra files
-// like resolv.conf). A source that is not a directory — a single-file bind
-// mount — cannot anchor an *os.Root, so it resolves to the file's parent
-// directory with the file's name as the relative path.
+// like resolv.conf). Source symlinks are resolved to the path selected when
+// the runtime creates the mount. A source that is not a directory — a
+// single-file bind mount — cannot anchor an *os.Root, so it resolves to the
+// file's parent directory with the file's name as the relative path.
 //
 // Writers must honor the readonly result: resolution bypasses the mount
 // namespace, so MS_RDONLY never intervenes on the backing directory.
@@ -118,13 +122,14 @@ func (t *containerFSTransferrer) Transfer(ctx context.Context, src, dst any, opt
 // the bundle at all.
 func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel string, readonly bool, err error) {
 	rootfs := filepath.Join(bundleContainerDir, "rootfs")
+	configPath := filepath.Join(bundleContainerDir, "config.json")
 
-	data, err := os.ReadFile(filepath.Join(bundleContainerDir, "config.json"))
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return rootfs, containerPath, false, nil
 		}
-		return "", "", false, fmt.Errorf("failed to read bundle config: %w", err)
+		return "", "", false, fmt.Errorf("failed to read bundle config %q: %w", configPath, err)
 	}
 
 	var spec struct {
@@ -139,27 +144,25 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 		} `json:"mounts"`
 	}
 	if err := json.Unmarshal(data, &spec); err != nil {
-		return rootfs, containerPath, false, nil
+		return "", "", false, fmt.Errorf("failed to parse bundle config %q: %w", configPath, err)
 	}
 
 	target := path.Clean("/" + containerPath)
 
-	var bestDest, bestSrc string
-	var bestReadonly bool
+	var mountDest, mountSrc string
+	var mountReadonly bool
 	for _, m := range spec.Mounts {
-		if m.Type != "bind" || m.Source == "" {
+		if m.Type != "bind" || m.Source == "" || m.Destination == "" {
 			continue
 		}
 		dest := path.Clean("/" + m.Destination)
 		if target != dest && !strings.HasPrefix(target, strings.TrimSuffix(dest, "/")+"/") {
 			continue
 		}
-		if len(dest) > len(bestDest) {
-			bestDest, bestSrc = dest, m.Source
-			bestReadonly = readOnlyMount(m.Options)
-		}
+		mountDest, mountSrc = dest, m.Source
+		mountReadonly = readOnlyMount(m.Options)
 	}
-	if bestDest == "" {
+	if mountDest == "" {
 		return rootfs, containerPath, spec.Root.Readonly, nil
 	}
 
@@ -167,33 +170,40 @@ func resolveMountRoot(bundleContainerDir, containerPath string) (root, rel strin
 	// accepting either form of absolute path keeps the unit tests, which
 	// mix spec-style Linux sources with host temp directories, portable
 	// to Windows hosts.
-	if !filepath.IsAbs(bestSrc) && !path.IsAbs(bestSrc) {
-		bestSrc = filepath.Join(bundleContainerDir, bestSrc)
+	if !filepath.IsAbs(mountSrc) && !path.IsAbs(mountSrc) {
+		mountSrc = filepath.Join(bundleContainerDir, mountSrc)
+	}
+	// A bind mount follows source symlinks when it is created. Use the same
+	// resolved path so later changes operate on the mounted object rather
+	// than on the symlink itself.
+	if resolved, err := filepath.EvalSymlinks(mountSrc); err == nil {
+		mountSrc = resolved
 	}
 
-	rel = strings.TrimPrefix(target, bestDest)
+	rel = strings.TrimPrefix(target, mountDest)
 
-	if fi, err := os.Stat(bestSrc); err == nil && !fi.IsDir() {
+	if fi, err := os.Stat(mountSrc); err == nil && !fi.IsDir() {
 		// Single-file mount: anchor at the parent directory. A residual
 		// rel below the file yields a path that fails with ENOTDIR when
 		// the caller stats it, which is the honest answer.
-		return filepath.Dir(bestSrc), filepath.Base(bestSrc) + rel, bestReadonly, nil
+		return filepath.Dir(mountSrc), filepath.Base(mountSrc) + rel, mountReadonly, nil
 	}
 
 	if rel == "" {
 		rel = "."
 	}
-	return bestSrc, rel, bestReadonly, nil
+	return mountSrc, rel, mountReadonly, nil
 }
 
-// readOnlyMount applies mount(8) semantics: the last "ro" or "rw" wins.
+// readOnlyMount applies mount(8) semantics: the last read-only or read-write
+// option wins, including their recursive variants.
 func readOnlyMount(options []string) bool {
 	readonly := false
 	for _, opt := range options {
 		switch opt {
-		case "ro":
+		case "ro", "rro":
 			readonly = true
-		case "rw":
+		case "rw", "rrw":
 			readonly = false
 		}
 	}
@@ -362,11 +372,11 @@ func readPath(r io.Reader, dir, dstPath, mediaType string, preserveOwnership boo
 
 	dst := root
 	if relDst != "." {
-		// A destination naming an existing non-directory — a plain
+		// A destination naming an existing regular file — a plain
 		// file in the rootfs, or the source of a single-file bind
 		// mount after resolution — receives the archived file's bytes
 		// rather than a tree extraction.
-		if fi, err := root.Stat(relDst); err == nil && !fi.IsDir() {
+		if fi, err := root.Lstat(relDst); err == nil && fi.Mode().IsRegular() {
 			return extractOverFile(root, relDst, r, preserveOwnership)
 		}
 		if err := root.MkdirAll(relDst, 0755); err != nil {
@@ -410,56 +420,67 @@ func readPath(r io.Reader, dir, dstPath, mediaType string, preserveOwnership boo
 // the file untouched; truncating in place keeps a bind-mount source's inode.
 func extractOverFile(dst *os.Root, target string, r io.Reader, preserveOwnership bool) error {
 	tr := tar.NewReader(r)
-	header, err := tr.Next()
-	if err == io.EOF {
-		return fmt.Errorf("cannot extract empty archive over file %s", target)
+	var header *tar.Header
+	for {
+		var err error
+		header, err = tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("cannot extract empty archive over file %s", target)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar header: %w", err)
+		}
+		// archive/tar hides per-file PAX and GNU long-name headers, but
+		// surfaces global PAX headers. They carry metadata, not a payload.
+		if header.Typeflag != tar.TypeXGlobalHeader {
+			break
+		}
 	}
-	if err != nil {
-		return fmt.Errorf("failed to read tar header: %w", err)
-	}
-	if header.Typeflag != tar.TypeReg {
+	if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA { //nolint:staticcheck // TypeRegA compatibility is intentional.
 		return fmt.Errorf("cannot extract %q over file %s: not a regular file", header.Name, target)
 	}
 
-	// A fixed name overwrites debris from an interrupted transfer.
-	tmp := target + ".transfer-tmp"
-	f, err := dst.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	tmp := path.Join(path.Dir(target), ".transfer-"+rand.Text())
+	f, err := dst.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to stage %s: %w", target, err)
 	}
-	defer dst.Remove(tmp)
+	defer func() {
+		f.Close()
+		dst.Remove(tmp)
+	}()
 	// Copy exactly the size the header declares; the tar reader
 	// bounds the entry anyway, and the explicit limit satisfies
 	// gosec's decompression-bomb rule (G110).
 	if _, err := io.CopyN(f, tr, header.Size); err != nil {
-		f.Close()
-		return err
+		return fmt.Errorf("failed to stage %q over file %s: %w", header.Name, target, err)
 	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	switch _, err := tr.Next(); {
-	case err == nil:
-		return fmt.Errorf("cannot extract multiple entries over file %s", target)
-	case err != io.EOF:
-		return fmt.Errorf("failed to read tar header: %w", err)
+validateArchive:
+	for {
+		next, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			break validateArchive
+		case err != nil:
+			return fmt.Errorf("failed to read tar header: %w", err)
+		case next.Typeflag != tar.TypeXGlobalHeader:
+			return fmt.Errorf("cannot extract multiple entries over file %s", target)
+		}
 	}
 
-	staged, err := dst.Open(tmp)
-	if err != nil {
-		return err
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to rewind staged data for %s: %w", target, err)
 	}
-	defer staged.Close()
 	out, err := dst.OpenFile(target, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open destination file %s: %w", target, err)
 	}
-	if _, err := io.Copy(out, staged); err != nil {
+	if _, err := io.Copy(out, f); err != nil {
 		out.Close()
-		return err
+		return fmt.Errorf("failed to extract %q over file %s: %w", header.Name, target, err)
 	}
 	if err := out.Close(); err != nil {
-		return err
+		return fmt.Errorf("failed to close destination file %s: %w", target, err)
 	}
 	if preserveOwnership {
 		if err := dst.Lchown(target, header.Uid, header.Gid); err != nil {
@@ -475,7 +496,7 @@ func extractTarEntry(dst *os.Root, target string, header *tar.Header, r io.Reade
 		if err := dst.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
 			return err
 		}
-	case tar.TypeReg:
+	case tar.TypeReg, tar.TypeRegA: //nolint:staticcheck // TypeRegA compatibility is intentional.
 		if err := dst.MkdirAll(path.Dir(target), 0755); err != nil {
 			return err
 		}

--- a/internal/transfer/containerfs_test.go
+++ b/internal/transfer/containerfs_test.go
@@ -110,7 +110,7 @@ func TestWritePathExportSymlinkEscapeBlocked(t *testing.T) {
 	buf := &bytes.Buffer{}
 	// Asking to copy /escape/secret. Lstat would have to traverse
 	// the symlink "/escape" out of the rootfs to reach "secret".
-	err := writePath(rootfs, "/escape/secret", buf, mediaTypeTar, false)
+	err := writePath(rootfs, "/escape/secret", "secret", buf, mediaTypeTar, false)
 	if err == nil {
 		t.Fatal("expected error when traversing symlink out of rootfs, got nil")
 	}
@@ -130,7 +130,7 @@ func TestWritePathExportPreservesSymlinks(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(rootfs, "/alias", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(rootfs, "/alias", "alias", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -168,7 +168,7 @@ func TestWritePathExportWalkContainsSymlinkToOutside(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(rootfs, "/dir", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(rootfs, "/dir", "dir", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -398,7 +398,7 @@ func TestRoundTripExportImport(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(src, "/a", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(src, "/a", "a", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -618,7 +618,7 @@ func TestWritePathExportRelativeDotDotPath(t *testing.T) {
 	// "../outside/secret" cleans to "outside/secret" (relative),
 	// which doesn't exist inside the rootfs.
 	buf := &bytes.Buffer{}
-	err := writePath(rootfs, "../outside/secret", buf, mediaTypeTar, false)
+	err := writePath(rootfs, "../outside/secret", "secret", buf, mediaTypeTar, false)
 	if err == nil {
 		t.Fatal("expected error for path escaping rootfs, got nil")
 	}
@@ -644,7 +644,7 @@ func TestWritePathExportNoWalk(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(rootfs, "/d", buf, mediaTypeTar, true); err != nil {
+	if err := writePath(rootfs, "/d", "d", buf, mediaTypeTar, true); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -676,7 +676,7 @@ func TestWritePathExportRootDoesNotLeakBundleName(t *testing.T) {
 	leaked := filepath.Base(rootfs) // e.g. "rootfs"
 
 	buf := &bytes.Buffer{}
-	if err := writePath(rootfs, "/", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(rootfs, "/", ".", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -717,7 +717,7 @@ func TestRoundTripExportRootImport(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(src, "/", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(src, "/", ".", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -787,7 +787,7 @@ func TestWritePathExportRootDotfilesPreserved(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	if err := writePath(rootfs, "/", buf, mediaTypeTar, false); err != nil {
+	if err := writePath(rootfs, "/", ".", buf, mediaTypeTar, false); err != nil {
 		t.Fatalf("writePath: %v", err)
 	}
 
@@ -956,7 +956,7 @@ func TestWritePathExportReadsBindSource(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := writePath(root, rel, &buf, mediaTypeTar, false); err != nil {
+	if err := writePath(root, rel, "payload.txt", &buf, mediaTypeTar, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -967,5 +967,225 @@ func TestWritePathExportReadsBindSource(t *testing.T) {
 	}
 	if string(e.body) != "mounted\n" {
 		t.Fatalf("archived %q, want the mounted content", e.body)
+	}
+}
+
+// TestResolveMountRootSingleFileMount pins resolution for bind mounts whose
+// source is a file: the root is the file's parent directory (an *os.Root
+// cannot anchor at a file), and a relative source is interpreted against the
+// bundle directory, as the runtime does for bundle extra files.
+func TestResolveMountRootSingleFileMount(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	if err := os.WriteFile(filepath.Join(bundle, "resolv.conf"), []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	extra := filepath.Join(bundle, "extra")
+	if err := os.MkdirAll(extra, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hosts := filepath.Join(extra, "hosts")
+	if err := os.WriteFile(hosts, []byte("127.0.0.1 localhost\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{
+		"/etc/resolv.conf": "resolv.conf", // relative to the bundle
+		"/etc/hosts":       hosts,         // absolute
+	})
+
+	for _, tc := range []struct {
+		path     string
+		wantRoot string
+		wantRel  string
+	}{
+		{"/etc/resolv.conf", bundle, "resolv.conf"},
+		{"/etc/hosts", extra, "hosts"},
+		// A path below a file mount cannot exist; the residual rel makes
+		// the caller's stat fail with ENOTDIR rather than silently
+		// resolving elsewhere.
+		{"/etc/hosts/sub", extra, "hosts/sub"},
+	} {
+		root, rel, err := resolveMountRoot(bundle, tc.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if root != tc.wantRoot || rel != tc.wantRel {
+			t.Errorf("%s -> (%q, %q), want (%q, %q)", tc.path, root, rel, tc.wantRoot, tc.wantRel)
+		}
+	}
+}
+
+// TestWritePathExportSingleFileBindMount exports a file-mount destination:
+// the archive must carry the mounted bytes under the container-view name,
+// even though the source file's own basename differs.
+func TestWritePathExportSingleFileBindMount(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "resolv-generated.conf")
+	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Shadowed rootfs entry with different content: the image may ship its
+	// own resolv.conf under the mount point.
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "resolv.conf"), []byte("shadowed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+
+	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := writePath(root, rel, "resolv.conf", &buf, mediaTypeTar, false); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := readTar(t, &buf)
+	e, ok := entries["resolv.conf"]
+	if !ok {
+		t.Fatalf("resolv.conf missing from archive, got %v", keys(entries))
+	}
+	if string(e.body) != "nameserver 10.0.0.1\n" {
+		t.Fatalf("archived %q, want the mounted content", e.body)
+	}
+}
+
+// TestReadPathImportOverSingleFileBindMount imports onto a file-mount
+// destination: the mount source's bytes are replaced in place — same inode,
+// so the container's mount keeps seeing the file — and the shadowed rootfs
+// entry stays untouched.
+func TestReadPathImportOverSingleFileBindMount(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "resolv.conf")
+	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "resolv.conf"), []byte("shadowed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": "resolv.conf"})
+
+	before, err := os.Stat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := writeTar(t, func(tw *tar.Writer) {
+		body := []byte("nameserver 10.0.0.2\n")
+		_ = tw.WriteHeader(&tar.Header{
+			Name:     "resolv.conf",
+			Typeflag: tar.TypeReg,
+			Mode:     0644,
+			Size:     int64(len(body)),
+		})
+		_, _ = tw.Write(body)
+	})
+
+	if err := readPath(buf, root, rel, mediaTypeTar, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "nameserver 10.0.0.2\n" {
+		t.Fatalf("source content = %q, want the imported bytes", got)
+	}
+	after, err := os.Stat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("source was replaced by a new inode; the container's mount would keep the stale file")
+	}
+	shadow, err := os.ReadFile(filepath.Join(rootfs, "etc", "resolv.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(shadow) != "shadowed\n" {
+		t.Fatalf("shadowed rootfs entry was modified: %q", shadow)
+	}
+}
+
+// TestReadPathImportDirectoryOverFileFails rejects extracting a directory
+// archive over a file-mount destination, mirroring "cannot copy a directory
+// to a file" semantics.
+func TestReadPathImportDirectoryOverFileFails(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "resolv.conf")
+	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+
+	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := writeTar(t, func(tw *tar.Writer) {
+		_ = tw.WriteHeader(&tar.Header{
+			Name:     "d",
+			Typeflag: tar.TypeDir,
+			Mode:     0755,
+		})
+	})
+
+	if err := readPath(buf, root, rel, mediaTypeTar, false); err == nil {
+		t.Fatal("expected error extracting a directory over a file destination")
+	}
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "nameserver 10.0.0.1\n" {
+		t.Fatalf("source was modified by a failed import: %q", got)
+	}
+}
+
+// TestWritePathExportDirMountExactKeepsName pins the naming contract when the
+// requested path is exactly a directory mount's destination: the walk anchors
+// at the mount source, but the archive's top-level name is the destination's
+// basename as the container sees it — Transfer derives it from the container
+// path, not from the resolved source.
+func TestWritePathExportDirMountExactKeepsName(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "bind-source")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "file"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+
+	root, rel, err := resolveMountRoot(bundle, "/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := writePath(root, rel, "data", &buf, mediaTypeTar, false); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := readTar(t, &buf)
+	if _, ok := entries["data/file"]; !ok {
+		t.Fatalf("expected 'data/file' entry, got %v", keys(entries))
+	}
+	if _, ok := entries[filepath.Base(source)+"/file"]; ok {
+		t.Fatal("archive leaked the mount source's basename instead of the container-view name")
 	}
 }

--- a/internal/transfer/containerfs_test.go
+++ b/internal/transfer/containerfs_test.go
@@ -19,6 +19,7 @@ package transfer
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -27,6 +28,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/containerd/errdefs"
 )
 
 // makeRootfs creates a temporary rootfs and a sibling "outside"
@@ -829,7 +832,7 @@ func writeBundleSpec(t *testing.T, bundle string, binds map[string]string) {
 func TestResolveMountRootNoSpec(t *testing.T) {
 	bundle, rootfs, _ := makeRootfs(t)
 
-	root, rel, err := resolveMountRoot(bundle, "/etc/hosts")
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/hosts")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -862,7 +865,7 @@ func TestResolveMountRootSelectsLongestDestination(t *testing.T) {
 		// A sibling whose name merely shares the prefix is not inside the mount.
 		{"/database", rootfs, "/database"},
 	} {
-		root, rel, err := resolveMountRoot(bundle, tc.path)
+		root, rel, _, err := resolveMountRoot(bundle, tc.path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -889,7 +892,7 @@ func TestReadPathImportLandsInBindSource(t *testing.T) {
 	}
 	writeBundleSpec(t, bundle, map[string]string{"/data": source})
 
-	root, rel, err := resolveMountRoot(bundle, "/data")
+	root, rel, _, err := resolveMountRoot(bundle, "/data")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -950,7 +953,7 @@ func TestWritePathExportReadsBindSource(t *testing.T) {
 	}
 	writeBundleSpec(t, bundle, map[string]string{"/data": source})
 
-	root, rel, err := resolveMountRoot(bundle, "/data/payload.txt")
+	root, rel, _, err := resolveMountRoot(bundle, "/data/payload.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1004,7 +1007,7 @@ func TestResolveMountRootSingleFileMount(t *testing.T) {
 		// resolving elsewhere.
 		{"/etc/hosts/sub", extra, "hosts/sub"},
 	} {
-		root, rel, err := resolveMountRoot(bundle, tc.path)
+		root, rel, _, err := resolveMountRoot(bundle, tc.path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1033,7 +1036,7 @@ func TestWritePathExportSingleFileBindMount(t *testing.T) {
 	}
 	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
 
-	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1076,7 +1079,7 @@ func TestReadPathImportOverSingleFileBindMount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1130,7 +1133,7 @@ func TestReadPathImportDirectoryOverFileFails(t *testing.T) {
 	}
 	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
 
-	root, rel, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,7 +1174,7 @@ func TestWritePathExportDirMountExactKeepsName(t *testing.T) {
 	}
 	writeBundleSpec(t, bundle, map[string]string{"/data": source})
 
-	root, rel, err := resolveMountRoot(bundle, "/data")
+	root, rel, _, err := resolveMountRoot(bundle, "/data")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1188,4 +1191,131 @@ func TestWritePathExportDirMountExactKeepsName(t *testing.T) {
 	if _, ok := entries[filepath.Base(source)+"/file"]; ok {
 		t.Fatal("archive leaked the mount source's basename instead of the container-view name")
 	}
+}
+
+// specMount and writeBundleSpecOpts write a config.json with full mount
+// declarations and the root filesystem's read-only flag, for tests that
+// exercise the readonly resolution writeBundleSpec's destination -> source
+// map cannot express.
+type specMount struct {
+	Destination string   `json:"destination"`
+	Type        string   `json:"type"`
+	Source      string   `json:"source"`
+	Options     []string `json:"options,omitempty"`
+}
+
+func writeBundleSpecOpts(t *testing.T, bundle string, rootReadonly bool, mounts []specMount) {
+	t.Helper()
+	spec := struct {
+		Root struct {
+			Readonly bool `json:"readonly"`
+		} `json:"root"`
+		Mounts []specMount `json:"mounts"`
+	}{Mounts: mounts}
+	spec.Root.Readonly = rootReadonly
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveMountRootReadOnly pins the readonly flag: a matched mount's
+// options decide with last-option-wins semantics, and a path no mount covers
+// falls back to the spec's root read-only flag — so a writable mount inside a
+// read-only root stays writable, as Docker treats volumes in a --read-only
+// container.
+func TestResolveMountRootReadOnly(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	writeBundleSpecOpts(t, bundle, true, []specMount{
+		{Destination: "/ro", Type: "bind", Source: "/mnt/ro", Options: []string{"rbind", "ro"}},
+		{Destination: "/rw", Type: "bind", Source: "/mnt/rw", Options: []string{"rbind"}},
+		{Destination: "/ro-then-rw", Type: "bind", Source: "/mnt/a", Options: []string{"rbind", "ro", "rw"}},
+		{Destination: "/rw-then-ro", Type: "bind", Source: "/mnt/b", Options: []string{"rbind", "rw", "ro"}},
+	})
+
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"/ro/file", true},
+		{"/rw/file", false},
+		{"/ro-then-rw/file", false},
+		{"/rw-then-ro/file", true},
+		// No mount covers the path: the read-only root decides.
+		{"/etc/hosts", true},
+	} {
+		_, _, readonly, err := resolveMountRoot(bundle, tc.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if readonly != tc.want {
+			t.Errorf("%s: readonly = %v, want %v", tc.path, readonly, tc.want)
+		}
+	}
+}
+
+// TestTransferImportToReadOnlyPathRejected is the write-side contract on
+// read-only destinations: a copy-to targeting a path backed by a read-only
+// bind mount — or by the rootfs of a container whose spec marks root
+// read-only — fails with ErrPermissionDenied and leaves the backing content
+// untouched. Resolution writes to the backing directory from outside the
+// mount namespace, where MS_RDONLY would not intervene, so the refusal is
+// what upholds the read-only contract the container sees.
+func TestTransferImportToReadOnlyPathRejected(t *testing.T) {
+	newBundle := func(t *testing.T) (bundleParent, bundle string) {
+		t.Helper()
+		bundleParent = t.TempDir()
+		bundle = filepath.Join(bundleParent, "c1")
+		if err := os.MkdirAll(filepath.Join(bundle, "rootfs"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		return bundleParent, bundle
+	}
+
+	// The rejection must come before the input stream is consumed, so a
+	// ReadStream with no backing stream must never get its Reader called.
+	transferTo := func(t *testing.T, bundleParent, containerPath string) error {
+		t.Helper()
+		return NewContainerFSTransferrer(bundleParent).Transfer(context.Background(),
+			&ReadStream{MediaType: mediaTypeTar},
+			&ContainerPath{ContainerID: "c1", Path: containerPath})
+	}
+
+	t.Run("read-only bind mount", func(t *testing.T) {
+		bundleParent, bundle := newBundle(t)
+		source := filepath.Join(bundle, "bind-source")
+		if err := os.MkdirAll(source, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(source, "keep"), []byte("ORIGINAL"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		writeBundleSpecOpts(t, bundle, false, []specMount{
+			{Destination: "/data", Type: "bind", Source: source, Options: []string{"rbind", "ro"}},
+		})
+
+		err := transferTo(t, bundleParent, "/data/keep")
+		if !errdefs.IsPermissionDenied(err) {
+			t.Fatalf("expected permission-denied error, got %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(source, "keep"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "ORIGINAL" {
+			t.Fatalf("read-only mount source was modified: %q", got)
+		}
+	})
+
+	t.Run("read-only rootfs", func(t *testing.T) {
+		bundleParent, bundle := newBundle(t)
+		writeBundleSpecOpts(t, bundle, true, nil)
+
+		if err := transferTo(t, bundleParent, "/etc/hosts"); !errdefs.IsPermissionDenied(err) {
+			t.Fatalf("expected permission-denied error, got %v", err)
+		}
+	})
 }

--- a/internal/transfer/containerfs_test.go
+++ b/internal/transfer/containerfs_test.go
@@ -19,6 +19,7 @@ package transfer
 import (
 	"archive/tar"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"io/fs"
@@ -796,5 +797,175 @@ func TestWritePathExportRootDotfilesPreserved(t *testing.T) {
 	}
 	if _, ok := entries["bashrc"]; ok {
 		t.Errorf("dotfile was renamed to 'bashrc' (leading dot stripped by TrimPrefix bug)")
+	}
+}
+
+// writeBundleSpec writes a config.json declaring the given bind mounts, as
+// destination -> source pairs.
+func writeBundleSpec(t *testing.T, bundle string, binds map[string]string) {
+	t.Helper()
+	type mount struct {
+		Destination string `json:"destination"`
+		Type        string `json:"type"`
+		Source      string `json:"source"`
+	}
+	spec := struct {
+		Mounts []mount `json:"mounts"`
+	}{}
+	for dest, src := range binds {
+		spec.Mounts = append(spec.Mounts, mount{Destination: dest, Type: "bind", Source: src})
+	}
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveMountRootNoSpec resolves to the rootfs when the bundle carries no
+// config.json, so a bundle without mount information behaves as before.
+func TestResolveMountRootNoSpec(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+
+	root, rel, err := resolveMountRoot(bundle, "/etc/hosts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != rootfs {
+		t.Fatalf("root = %q, want %q", root, rootfs)
+	}
+	if rel != "/etc/hosts" {
+		t.Fatalf("rel = %q, want %q", rel, "/etc/hosts")
+	}
+}
+
+// TestResolveMountRootSelectsLongestDestination pins the nesting rule: a path
+// covered by two mounts resolves against the innermost one.
+func TestResolveMountRootSelectsLongestDestination(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	writeBundleSpec(t, bundle, map[string]string{
+		"/data":       "/mnt/outer",
+		"/data/inner": "/mnt/inner",
+	})
+
+	for _, tc := range []struct {
+		path     string
+		wantRoot string
+		wantRel  string
+	}{
+		{"/data/file", "/mnt/outer", "/file"},
+		{"/data/inner/file", "/mnt/inner", "/file"},
+		{"/data", "/mnt/outer", "."},
+		{"/elsewhere/file", rootfs, "/elsewhere/file"},
+		// A sibling whose name merely shares the prefix is not inside the mount.
+		{"/database", rootfs, "/database"},
+	} {
+		root, rel, err := resolveMountRoot(bundle, tc.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if root != tc.wantRoot || rel != tc.wantRel {
+			t.Errorf("%s -> (%q, %q), want (%q, %q)", tc.path, root, rel, tc.wantRoot, tc.wantRel)
+		}
+	}
+}
+
+// TestReadPathImportLandsInBindSource is the observable effect on the import
+// side: extracting to a bind-mounted destination must produce the file in the
+// mount's source directory, where the container reads it through the mount —
+// not in the shadowed rootfs entry underneath.
+func TestReadPathImportLandsInBindSource(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "bind-source")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// The shadowed directory exists in the rootfs, as it does for a real
+	// container: the runtime creates the mount point before mounting over it.
+	if err := os.MkdirAll(filepath.Join(rootfs, "data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+
+	root, rel, err := resolveMountRoot(bundle, "/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	body := []byte("through the mount\n")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "payload.txt",
+		Mode:     0644,
+		Size:     int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := readPath(&buf, root, rel, mediaTypeTar, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(source, "payload.txt"))
+	if err != nil {
+		t.Fatalf("file missing from the bind source: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("content = %q, want %q", got, body)
+	}
+	if _, err := os.Stat(filepath.Join(rootfs, "data", "payload.txt")); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("file was written to the shadowed rootfs entry, where the container cannot see it")
+	}
+}
+
+// TestWritePathExportReadsBindSource is the same effect on the export side: an
+// archive of a bind-mounted path must carry the mounted content, not whatever
+// the shadowed rootfs entry holds.
+func TestWritePathExportReadsBindSource(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "bind-source")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "payload.txt"), []byte("mounted\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Same name under the shadowed rootfs entry, with different content: if
+	// resolution is wrong the export silently returns this instead.
+	if err := os.MkdirAll(filepath.Join(rootfs, "data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "data", "payload.txt"), []byte("shadowed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+
+	root, rel, err := resolveMountRoot(bundle, "/data/payload.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := writePath(root, rel, &buf, mediaTypeTar, false); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := readTar(t, &buf)
+	e, ok := entries["payload.txt"]
+	if !ok {
+		t.Fatalf("payload.txt missing from archive, got %v", entries)
+	}
+	if string(e.body) != "mounted\n" {
+		t.Fatalf("archived %q, want the mounted content", e.body)
 	}
 }

--- a/internal/transfer/containerfs_test.go
+++ b/internal/transfer/containerfs_test.go
@@ -1158,6 +1158,78 @@ func TestReadPathImportDirectoryOverFileFails(t *testing.T) {
 	}
 }
 
+// TestReadPathImportMultipleEntriesOverFileLeavesTargetUntouched rejects a
+// multi-entry archive at a file destination without touching the file.
+func TestReadPathImportMultipleEntriesOverFileLeavesTargetUntouched(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "resolv.conf")
+	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := writeTar(t, func(tw *tar.Writer) {
+		for _, name := range []string{"first", "second"} {
+			body := []byte("OWNED " + name + "\n")
+			_ = tw.WriteHeader(&tar.Header{
+				Name:     name,
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+				Size:     int64(len(body)),
+			})
+			_, _ = tw.Write(body)
+		}
+	})
+
+	if err := readPath(buf, root, rel, mediaTypeTar, false); err == nil {
+		t.Fatal("expected error extracting multiple entries over a file destination")
+	}
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "nameserver 10.0.0.1\n" {
+		t.Fatalf("target was modified by a failed import: %q", got)
+	}
+	if _, err := os.Stat(source + ".transfer-tmp"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("staging file left behind after a failed import")
+	}
+}
+
+// TestReadPathImportEmptyArchiveOverFileFails rejects an empty archive at a
+// file destination instead of succeeding without replacing anything.
+func TestReadPathImportEmptyArchiveOverFileFails(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	source := filepath.Join(bundle, "resolv.conf")
+	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+
+	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := writeTar(t, func(tw *tar.Writer) {})
+
+	if err := readPath(buf, root, rel, mediaTypeTar, false); err == nil {
+		t.Fatal("expected error extracting an empty archive over a file destination")
+	}
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "nameserver 10.0.0.1\n" {
+		t.Fatalf("source was modified by a failed import: %q", got)
+	}
+}
+
 // TestWritePathExportDirMountExactKeepsName pins the naming contract when the
 // requested path is exactly a directory mount's destination: the walk anchors
 // at the mount source, but the archive's top-level name is the destination's
@@ -1193,10 +1265,6 @@ func TestWritePathExportDirMountExactKeepsName(t *testing.T) {
 	}
 }
 
-// specMount and writeBundleSpecOpts write a config.json with full mount
-// declarations and the root filesystem's read-only flag, for tests that
-// exercise the readonly resolution writeBundleSpec's destination -> source
-// map cannot express.
 type specMount struct {
 	Destination string   `json:"destination"`
 	Type        string   `json:"type"`
@@ -1222,11 +1290,8 @@ func writeBundleSpecOpts(t *testing.T, bundle string, rootReadonly bool, mounts 
 	}
 }
 
-// TestResolveMountRootReadOnly pins the readonly flag: a matched mount's
-// options decide with last-option-wins semantics, and a path no mount covers
-// falls back to the spec's root read-only flag — so a writable mount inside a
-// read-only root stays writable, as Docker treats volumes in a --read-only
-// container.
+// TestResolveMountRootReadOnly pins the readonly flag: the last ro/rw option
+// wins, and a path no mount covers falls back to the spec's root flag.
 func TestResolveMountRootReadOnly(t *testing.T) {
 	bundle, _, _ := makeRootfs(t)
 	writeBundleSpecOpts(t, bundle, true, []specMount{
@@ -1257,13 +1322,8 @@ func TestResolveMountRootReadOnly(t *testing.T) {
 	}
 }
 
-// TestTransferImportToReadOnlyPathRejected is the write-side contract on
-// read-only destinations: a copy-to targeting a path backed by a read-only
-// bind mount — or by the rootfs of a container whose spec marks root
-// read-only — fails with ErrPermissionDenied and leaves the backing content
-// untouched. Resolution writes to the backing directory from outside the
-// mount namespace, where MS_RDONLY would not intervene, so the refusal is
-// what upholds the read-only contract the container sees.
+// TestTransferImportToReadOnlyPathRejected verifies copy-to into a read-only
+// mount or rootfs fails with ErrPermissionDenied, the backing bytes intact.
 func TestTransferImportToReadOnlyPathRejected(t *testing.T) {
 	newBundle := func(t *testing.T) (bundleParent, bundle string) {
 		t.Helper()
@@ -1275,8 +1335,7 @@ func TestTransferImportToReadOnlyPathRejected(t *testing.T) {
 		return bundleParent, bundle
 	}
 
-	// The rejection must come before the input stream is consumed, so a
-	// ReadStream with no backing stream must never get its Reader called.
+	// A ReadStream with no backing stream asserts the rejection precedes any read.
 	transferTo := func(t *testing.T, bundleParent, containerPath string) error {
 		t.Helper()
 		return NewContainerFSTransferrer(bundleParent).Transfer(context.Background(),

--- a/internal/transfer/containerfs_test.go
+++ b/internal/transfer/containerfs_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -91,6 +92,38 @@ func writeTar(t *testing.T, build func(tw *tar.Writer)) *bytes.Buffer {
 	}
 	return buf
 }
+
+// writeLegacyRegularTar writes a raw legacy regular-file typeflag. tar.Writer
+// promotes TypeRegA to TypeReg, so the typeflag and checksum must be adjusted
+// after writing the archive.
+func writeLegacyRegularTar(t *testing.T, name, body string) *bytes.Buffer {
+	t.Helper()
+	buf := writeTar(t, func(tw *tar.Writer) {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     0644,
+			Size:     int64(len(body)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("tar body: %v", err)
+		}
+	})
+
+	header := buf.Bytes()[:tarBlockSize]
+	header[156] = tar.TypeRegA //nolint:staticcheck // Exercise a legacy tar typeflag.
+	copy(header[148:156], "        ")
+	var checksum int
+	for _, b := range header {
+		checksum += int(b)
+	}
+	copy(header[148:156], fmt.Sprintf("%06o\x00 ", checksum))
+	return buf
+}
+
+const tarBlockSize = 512
 
 // TestWritePathExportSymlinkEscapeBlocked verifies that when a tar
 // export hits a regular file whose path would resolve outside the
@@ -377,6 +410,50 @@ func TestReadPathImportRoundTrip(t *testing.T) {
 	if string(hard) != "hello" {
 		t.Fatalf("d/hard body: %q", hard)
 	}
+}
+
+// TestReadPathImportLegacyRegularFile verifies that the legacy zero typeflag
+// extracts as a regular file for both directory and existing-file
+// destinations.
+func TestReadPathImportLegacyRegularFile(t *testing.T) {
+	t.Run("directory destination", func(t *testing.T) {
+		_, rootfs, _ := makeRootfs(t)
+		if err := os.Mkdir(filepath.Join(rootfs, "dst"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		buf := writeLegacyRegularTar(t, "payload", "legacy")
+		if err := readPath(buf, rootfs, "/dst", mediaTypeTar, false); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(filepath.Join(rootfs, "dst", "payload"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "legacy" {
+			t.Fatalf("payload = %q, want %q", got, "legacy")
+		}
+	})
+
+	t.Run("file destination", func(t *testing.T) {
+		_, rootfs, _ := makeRootfs(t)
+		target := filepath.Join(rootfs, "target")
+		if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		buf := writeLegacyRegularTar(t, "payload", "legacy")
+		if err := readPath(buf, rootfs, "/target", mediaTypeTar, false); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "legacy" {
+			t.Fatalf("target = %q, want %q", got, "legacy")
+		}
+	})
 }
 
 // TestRoundTripExportImport writes some files into a rootfs, exports
@@ -803,28 +880,14 @@ func TestWritePathExportRootDotfilesPreserved(t *testing.T) {
 	}
 }
 
-// writeBundleSpec writes a config.json declaring the given bind mounts, as
-// destination -> source pairs.
-func writeBundleSpec(t *testing.T, bundle string, binds map[string]string) {
+// writeBundleSpec writes a config.json declaring bind mounts in the order
+// provided.
+func writeBundleSpec(t *testing.T, bundle string, binds ...specMount) {
 	t.Helper()
-	type mount struct {
-		Destination string `json:"destination"`
-		Type        string `json:"type"`
-		Source      string `json:"source"`
+	for i := range binds {
+		binds[i].Type = "bind"
 	}
-	spec := struct {
-		Mounts []mount `json:"mounts"`
-	}{}
-	for dest, src := range binds {
-		spec.Mounts = append(spec.Mounts, mount{Destination: dest, Type: "bind", Source: src})
-	}
-	data, err := json.Marshal(spec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(bundle, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeBundleSpecOpts(t, bundle, false, binds)
 }
 
 // TestResolveMountRootNoSpec resolves to the rootfs when the bundle carries no
@@ -844,23 +907,92 @@ func TestResolveMountRootNoSpec(t *testing.T) {
 	}
 }
 
-// TestResolveMountRootSelectsLongestDestination pins the nesting rule: a path
-// covered by two mounts resolves against the innermost one.
-func TestResolveMountRootSelectsLongestDestination(t *testing.T) {
+func TestResolveMountRootRejectsMalformedSpec(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	configPath := filepath.Join(bundle, "config.json")
+	if err := os.WriteFile(configPath, []byte("{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := resolveMountRoot(bundle, "/etc/hosts"); err == nil {
+		t.Fatal("expected malformed config.json to fail resolution")
+	} else if !strings.Contains(err.Error(), fmt.Sprintf("%q", configPath)) {
+		t.Fatalf("error = %q, want config path %q", err, configPath)
+	}
+}
+
+func TestResolveMountRootReportsUnreadableSpecPath(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	configPath := filepath.Join(bundle, "config.json")
+	if err := os.Mkdir(configPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := resolveMountRoot(bundle, "/etc/hosts"); err == nil {
+		t.Fatal("expected unreadable config.json to fail resolution")
+	} else if !strings.Contains(err.Error(), fmt.Sprintf("%q", configPath)) {
+		t.Fatalf("error = %q, want config path %q", err, configPath)
+	}
+}
+
+// TestResolveMountRootUsesLastMatchingDestination pins OCI mount ordering: a
+// later parent mount hides an earlier child just as a later child overlays an
+// earlier parent.
+func TestResolveMountRootUsesLastMatchingDestination(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mounts       []specMount
+		wantRoot     string
+		wantRel      string
+		wantReadonly bool
+	}{
+		{
+			name: "parent before child",
+			mounts: []specMount{
+				{Destination: "/data", Type: "bind", Source: "/mnt/outer", Options: []string{"ro"}},
+				{Destination: "/data/inner", Type: "bind", Source: "/mnt/inner", Options: []string{"rw"}},
+			},
+			wantRoot: "/mnt/inner",
+			wantRel:  "/file",
+		},
+		{
+			name: "child before parent",
+			mounts: []specMount{
+				{Destination: "/data/inner", Type: "bind", Source: "/mnt/inner", Options: []string{"rw"}},
+				{Destination: "/data", Type: "bind", Source: "/mnt/outer", Options: []string{"ro"}},
+			},
+			wantRoot:     "/mnt/outer",
+			wantRel:      "/inner/file",
+			wantReadonly: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle, _, _ := makeRootfs(t)
+			writeBundleSpecOpts(t, bundle, false, tc.mounts)
+
+			root, rel, readonly, err := resolveMountRoot(bundle, "/data/inner/file")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if root != tc.wantRoot || rel != tc.wantRel || readonly != tc.wantReadonly {
+				t.Errorf("resolved to (%q, %q, readonly=%v), want (%q, %q, readonly=%v)",
+					root, rel, readonly, tc.wantRoot, tc.wantRel, tc.wantReadonly)
+			}
+		})
+	}
+}
+
+func TestResolveMountRootMatchesPathBoundary(t *testing.T) {
 	bundle, rootfs, _ := makeRootfs(t)
-	writeBundleSpec(t, bundle, map[string]string{
-		"/data":       "/mnt/outer",
-		"/data/inner": "/mnt/inner",
-	})
+	writeBundleSpec(t, bundle, specMount{Destination: "/data", Source: "/mnt/data"})
 
 	for _, tc := range []struct {
 		path     string
 		wantRoot string
 		wantRel  string
 	}{
-		{"/data/file", "/mnt/outer", "/file"},
-		{"/data/inner/file", "/mnt/inner", "/file"},
-		{"/data", "/mnt/outer", "."},
+		{"/data/file", "/mnt/data", "/file"},
+		{"/data", "/mnt/data", "."},
 		{"/elsewhere/file", rootfs, "/elsewhere/file"},
 		// A sibling whose name merely shares the prefix is not inside the mount.
 		{"/database", rootfs, "/database"},
@@ -871,6 +1003,31 @@ func TestResolveMountRootSelectsLongestDestination(t *testing.T) {
 		}
 		if root != tc.wantRoot || rel != tc.wantRel {
 			t.Errorf("%s -> (%q, %q), want (%q, %q)", tc.path, root, rel, tc.wantRoot, tc.wantRel)
+		}
+	}
+}
+
+func TestResolveMountRootHandlesLegacyRelativeDestination(t *testing.T) {
+	bundle, rootfs, _ := makeRootfs(t)
+	writeBundleSpec(t, bundle,
+		specMount{Destination: "", Source: "/mnt/empty"},
+		specMount{Destination: "relative", Source: "/mnt/relative"},
+	)
+
+	for _, tc := range []struct {
+		containerPath string
+		wantRoot      string
+		wantRel       string
+	}{
+		{containerPath: "/etc/hosts", wantRoot: rootfs, wantRel: "/etc/hosts"},
+		{containerPath: "/relative/file", wantRoot: "/mnt/relative", wantRel: "/file"},
+	} {
+		root, rel, _, err := resolveMountRoot(bundle, tc.containerPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if root != tc.wantRoot || rel != tc.wantRel {
+			t.Errorf("%s -> (%q, %q), want (%q, %q)", tc.containerPath, root, rel, tc.wantRoot, tc.wantRel)
 		}
 	}
 }
@@ -890,7 +1047,7 @@ func TestReadPathImportLandsInBindSource(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(rootfs, "data"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/data", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/data")
 	if err != nil {
@@ -951,7 +1108,7 @@ func TestWritePathExportReadsBindSource(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rootfs, "data", "payload.txt"), []byte("shadowed\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/data", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/data/payload.txt")
 	if err != nil {
@@ -979,6 +1136,10 @@ func TestWritePathExportReadsBindSource(t *testing.T) {
 // bundle directory, as the runtime does for bundle extra files.
 func TestResolveMountRootSingleFileMount(t *testing.T) {
 	bundle, _, _ := makeRootfs(t)
+	resolvedBundle, err := filepath.EvalSymlinks(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(bundle, "resolv.conf"), []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -986,26 +1147,36 @@ func TestResolveMountRootSingleFileMount(t *testing.T) {
 	if err := os.MkdirAll(extra, 0755); err != nil {
 		t.Fatal(err)
 	}
+	resolvedExtra, err := filepath.EvalSymlinks(extra)
+	if err != nil {
+		t.Fatal(err)
+	}
 	hosts := filepath.Join(extra, "hosts")
 	if err := os.WriteFile(hosts, []byte("127.0.0.1 localhost\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{
-		"/etc/resolv.conf": "resolv.conf", // relative to the bundle
-		"/etc/hosts":       hosts,         // absolute
-	})
+	hostsLink := filepath.Join(bundle, "hosts-link")
+	if err := os.Symlink(hosts, hostsLink); err != nil {
+		t.Fatal(err)
+	}
+	writeBundleSpec(t, bundle,
+		specMount{Destination: "/etc/resolv.conf", Source: "resolv.conf"}, // relative to the bundle
+		specMount{Destination: "/etc/hosts", Source: hosts},               // absolute
+		specMount{Destination: "/etc/hostname", Source: hostsLink},        // symlink to a file
+	)
 
 	for _, tc := range []struct {
 		path     string
 		wantRoot string
 		wantRel  string
 	}{
-		{"/etc/resolv.conf", bundle, "resolv.conf"},
-		{"/etc/hosts", extra, "hosts"},
+		{"/etc/resolv.conf", resolvedBundle, "resolv.conf"},
+		{"/etc/hosts", resolvedExtra, "hosts"},
+		{"/etc/hostname", resolvedExtra, "hosts"},
 		// A path below a file mount cannot exist; the residual rel makes
 		// the caller's stat fail with ENOTDIR rather than silently
 		// resolving elsewhere.
-		{"/etc/hosts/sub", extra, "hosts/sub"},
+		{"/etc/hosts/sub", resolvedExtra, "hosts/sub"},
 	} {
 		root, rel, _, err := resolveMountRoot(bundle, tc.path)
 		if err != nil {
@@ -1034,7 +1205,7 @@ func TestWritePathExportSingleFileBindMount(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rootfs, "etc", "resolv.conf"), []byte("shadowed\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/etc/resolv.conf", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
@@ -1066,13 +1237,17 @@ func TestReadPathImportOverSingleFileBindMount(t *testing.T) {
 	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
+	stagingLookalike := source + ".transfer-tmp"
+	if err := os.WriteFile(stagingLookalike, []byte("keep\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(rootfs, "etc", "resolv.conf"), []byte("shadowed\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": "resolv.conf"})
+	writeBundleSpec(t, bundle, specMount{Destination: "/etc/resolv.conf", Source: "resolv.conf"})
 
 	before, err := os.Stat(source)
 	if err != nil {
@@ -1120,6 +1295,13 @@ func TestReadPathImportOverSingleFileBindMount(t *testing.T) {
 	if string(shadow) != "shadowed\n" {
 		t.Fatalf("shadowed rootfs entry was modified: %q", shadow)
 	}
+	lookalike, err := os.ReadFile(stagingLookalike)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(lookalike) != "keep\n" {
+		t.Fatalf("staging lookalike was modified: %q", lookalike)
+	}
 }
 
 // TestReadPathImportDirectoryOverFileFails rejects extracting a directory
@@ -1131,7 +1313,7 @@ func TestReadPathImportDirectoryOverFileFails(t *testing.T) {
 	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/etc/resolv.conf", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
@@ -1166,7 +1348,7 @@ func TestReadPathImportMultipleEntriesOverFileLeavesTargetUntouched(t *testing.T
 	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/etc/resolv.conf", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
@@ -1196,8 +1378,62 @@ func TestReadPathImportMultipleEntriesOverFileLeavesTargetUntouched(t *testing.T
 	if string(got) != "nameserver 10.0.0.1\n" {
 		t.Fatalf("target was modified by a failed import: %q", got)
 	}
-	if _, err := os.Stat(source + ".transfer-tmp"); !errors.Is(err, fs.ErrNotExist) {
-		t.Fatal("staging file left behind after a failed import")
+	entries, err := os.ReadDir(filepath.Dir(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".transfer-") {
+			t.Fatalf("staging file left behind after a failed import: %s", entry.Name())
+		}
+	}
+}
+
+func TestReadPathImportGlobalPAXHeaderOverFile(t *testing.T) {
+	_, rootfs, _ := makeRootfs(t)
+	target := filepath.Join(rootfs, "target")
+	if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte("replacement")
+	buf := writeTar(t, func(tw *tar.Writer) {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:       "pax_global_header",
+			Typeflag:   tar.TypeXGlobalHeader,
+			PAXRecords: map[string]string{"comment": "metadata"},
+		}); err != nil {
+			t.Fatalf("write global PAX header: %v", err)
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "payload",
+			Typeflag: tar.TypeReg,
+			Mode:     0644,
+			Size:     int64(len(body)),
+		}); err != nil {
+			t.Fatalf("write payload header: %v", err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatalf("write payload: %v", err)
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:       "pax_global_footer",
+			Typeflag:   tar.TypeXGlobalHeader,
+			PAXRecords: map[string]string{"comment": "trailing metadata"},
+		}); err != nil {
+			t.Fatalf("write trailing global PAX header: %v", err)
+		}
+	})
+
+	if err := readPath(buf, rootfs, "/target", mediaTypeTar, false); err != nil {
+		t.Fatalf("import with global PAX metadata: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("target content = %q, want %q", got, body)
 	}
 }
 
@@ -1209,7 +1445,7 @@ func TestReadPathImportEmptyArchiveOverFileFails(t *testing.T) {
 	if err := os.WriteFile(source, []byte("nameserver 10.0.0.1\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/etc/resolv.conf": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/etc/resolv.conf", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/etc/resolv.conf")
 	if err != nil {
@@ -1230,6 +1466,42 @@ func TestReadPathImportEmptyArchiveOverFileFails(t *testing.T) {
 	}
 }
 
+// TestReadPathImportOverSymlinkDestinationFails verifies that only an
+// existing regular file activates the single-file import path. A symlink is
+// not treated as a file destination, even when it points to a regular file.
+func TestReadPathImportOverSymlinkDestinationFails(t *testing.T) {
+	_, rootfs, _ := makeRootfs(t)
+	target := filepath.Join(rootfs, "target")
+	if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target", filepath.Join(rootfs, "destination")); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := writeTar(t, func(tw *tar.Writer) {
+		body := []byte("replacement")
+		_ = tw.WriteHeader(&tar.Header{
+			Name:     "payload",
+			Typeflag: tar.TypeReg,
+			Mode:     0644,
+			Size:     int64(len(body)),
+		})
+		_, _ = tw.Write(body)
+	})
+
+	if err := readPath(buf, rootfs, "/destination", mediaTypeTar, false); err == nil {
+		t.Fatal("expected error extracting over a symlink destination")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("symlink target was modified: %q", got)
+	}
+}
+
 // TestWritePathExportDirMountExactKeepsName pins the naming contract when the
 // requested path is exactly a directory mount's destination: the walk anchors
 // at the mount source, but the archive's top-level name is the destination's
@@ -1244,7 +1516,7 @@ func TestWritePathExportDirMountExactKeepsName(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(source, "file"), []byte("x"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeBundleSpec(t, bundle, map[string]string{"/data": source})
+	writeBundleSpec(t, bundle, specMount{Destination: "/data", Source: source})
 
 	root, rel, _, err := resolveMountRoot(bundle, "/data")
 	if err != nil {
@@ -1290,8 +1562,9 @@ func writeBundleSpecOpts(t *testing.T, bundle string, rootReadonly bool, mounts 
 	}
 }
 
-// TestResolveMountRootReadOnly pins the readonly flag: the last ro/rw option
-// wins, and a path no mount covers falls back to the spec's root flag.
+// TestResolveMountRootReadOnly pins the readonly flag: the last ro/rw option,
+// including recursive variants, wins, and a path no mount covers falls back
+// to the spec's root flag.
 func TestResolveMountRootReadOnly(t *testing.T) {
 	bundle, _, _ := makeRootfs(t)
 	writeBundleSpecOpts(t, bundle, true, []specMount{
@@ -1299,6 +1572,9 @@ func TestResolveMountRootReadOnly(t *testing.T) {
 		{Destination: "/rw", Type: "bind", Source: "/mnt/rw", Options: []string{"rbind"}},
 		{Destination: "/ro-then-rw", Type: "bind", Source: "/mnt/a", Options: []string{"rbind", "ro", "rw"}},
 		{Destination: "/rw-then-ro", Type: "bind", Source: "/mnt/b", Options: []string{"rbind", "rw", "ro"}},
+		{Destination: "/rro", Type: "bind", Source: "/mnt/rro", Options: []string{"rbind", "rro"}},
+		{Destination: "/rro-then-rrw", Type: "bind", Source: "/mnt/c", Options: []string{"rbind", "rro", "rrw"}},
+		{Destination: "/rrw-then-rro", Type: "bind", Source: "/mnt/d", Options: []string{"rbind", "rrw", "rro"}},
 	})
 
 	for _, tc := range []struct {
@@ -1309,6 +1585,9 @@ func TestResolveMountRootReadOnly(t *testing.T) {
 		{"/rw/file", false},
 		{"/ro-then-rw/file", false},
 		{"/rw-then-ro/file", true},
+		{"/rro/file", true},
+		{"/rro-then-rrw/file", false},
+		{"/rrw-then-rro/file", true},
 		// No mount covers the path: the read-only root decides.
 		{"/etc/hosts", true},
 	} {
@@ -1319,6 +1598,23 @@ func TestResolveMountRootReadOnly(t *testing.T) {
 		if readonly != tc.want {
 			t.Errorf("%s: readonly = %v, want %v", tc.path, readonly, tc.want)
 		}
+	}
+}
+
+func TestResolveMountRootDuplicateDestinationUsesLast(t *testing.T) {
+	bundle, _, _ := makeRootfs(t)
+	writeBundleSpecOpts(t, bundle, false, []specMount{
+		{Destination: "/data", Type: "bind", Source: "/mnt/first", Options: []string{"ro"}},
+		{Destination: "/data", Type: "bind", Source: "/mnt/second", Options: []string{"rw"}},
+	})
+
+	root, rel, readonly, err := resolveMountRoot(bundle, "/data/file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != "/mnt/second" || rel != "/file" || readonly {
+		t.Fatalf("resolved to (%q, %q, readonly=%v), want (%q, %q, readonly=false)",
+			root, rel, readonly, "/mnt/second", "/file")
 	}
 }
 


### PR DESCRIPTION
Supersedes #260.

This PR contains #260's two commits unchanged, preserving their authorship, plus the read-only enforcement and file-import hardening added during follow-up review. It is intended to merge directly into `main` as the complete mount-aware transfer change.

## Problem

The container-FS transferrer anchors imports and exports at the bundle's rootfs. That directory only backs paths not covered by a mount: when the OCI spec declares a bind mount, its source shadows the corresponding rootfs path inside the container.

As a result:

- importing to a bind-mounted path can report success after writing a file the container never sees;
- exporting from that path can archive stale or unrelated rootfs content; and
- resolving directly to a bind source without honoring mount options can bypass the container's read-only view and modify host-backed content exposed as `ro`.

## Changes

### Resolve paths against bind mounts

`resolveMountRoot` reads the bundle spec and maps a container-view path to the directory that backs it. The last matching bind mount in spec order wins, so a later parent mount can hide an earlier child mount. Both transfer directions use the resolved path.

The resolver also:

- interprets relative mount sources against the bundle directory;
- interprets deprecated relative mount destinations against `/`, as required by OCI on Linux;
- handles single-file bind mounts by anchoring `os.Root` at the source's parent;
- preserves the container-view name when exporting, even if the source basename differs; and
- updates an existing file destination in place so a single-file bind mount keeps the same inode.

### Enforce the container's read-only view

Resolution happens outside the mount namespace where `MS_RDONLY` is enforced, so the resolver now reports whether the destination is write-protected:

- the matched mount's options use last-option-wins `ro`/`rw` and recursive `rro`/`rrw` semantics; or
- when no mount covers the path, the OCI spec's `root.readonly` flag applies.

Copy-to rejects a read-only destination with `ErrPermissionDenied` before opening the input stream. A writable mount inside a read-only root remains writable, matching Docker semantics. Exports remain allowed.

### Validate file-destination imports before mutation

An import over an existing file must contain exactly one regular file. The payload is staged in a temporary sibling and the complete archive is validated before the destination is truncated in place. Empty, truncated, non-regular, or multi-entry archives therefore fail without changing the original file or leaving staging debris.

## Bundle-spec behavior

A missing `config.json` falls back to the rootfs. A config that exists but cannot be read or parsed returns an error: resolving blindly could write to a shadowed path or bypass a read-only mount.

## Known limitations

Issue #164 continues to track paths whose subtree crosses into a deeper mount and non-bind mount types, such as `tmpfs`, whose contents only exist in the container's mount namespace.

## Tests

- Mount selection, relative sources and destinations, single-file mounts, and container-view archive names.
- Import and export against bind sources.
- Last-option-wins `ro`/`rw` and `rro`/`rrw` behavior and the read-only-root fallback.
- End-to-end rejection of imports to read-only mounts and root filesystems before the stream is opened.
- Missing-config fallback and malformed-config rejection.
- Global PAX metadata plus empty, malformed, and multi-entry archives over file destinations, including preservation of the original bytes and inode.
