### PR TITLE
fix(shim): reduce critical sections in local sandbox

### DIFF
--- a/internal/shim/sandbox/vm/vm.go
+++ b/internal/shim/sandbox/vm/vm.go
@@ -39,6 +39,11 @@ type localsandbox struct {
 	mu       sync.Mutex
 	vmm      vm.Manager
 	instance vm.Instance
+	// stopping is set while a Stop call is tearing down instance. It
+	// serializes concurrent Stop calls against each other and makes
+	// Client/StartStream fail fast instead of racing a call against an
+	// in-flight Shutdown.
+	stopping bool
 }
 
 // diskReserver is a package-private optional interface for vm.Manager
@@ -138,39 +143,86 @@ func (s *localsandbox) Start(ctx context.Context, opts ...sandbox.Opt) error {
 }
 
 func (s *localsandbox) Stop(ctx context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.instance == nil {
-		return fmt.Errorf("sandbox must be started: %w", errdefs.ErrFailedPrecondition)
-	}
-
-	if err := s.instance.Shutdown(ctx); err != nil {
+	instance, err := s.beginStopping()
+	if err != nil {
 		return err
 	}
 
-	s.instance = nil
+	stopped := false
+	defer func() {
+		s.mu.Lock()
+		if stopped {
+			// Stopped successful so clear vm instance.
+			s.instance = nil
+		}
+		s.stopping = false
+		s.mu.Unlock()
+	}()
+
+	if err := instance.Shutdown(ctx); err != nil {
+		return err
+	}
+
+	stopped = true
 	return nil
 }
 
 func (s *localsandbox) Client() (*ttrpc.Client, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.instance == nil {
-		return nil, fmt.Errorf("sandbox must be started: %w", errdefs.ErrFailedPrecondition)
+	instance, err := s.activeInstance()
+	if err != nil {
+		return nil, err
 	}
 
-	return s.instance.Client(), nil
+	// A live instance can still hand back a nil client if a previous Stop
+	// call failed partway through tearing it down (e.g. the underlying
+	// Shutdown cleared its client but then failed on a later step, so
+	// s.instance was deliberately left set for a retry). Surface that as
+	// an unavailable error instead of a nil client with a nil error.
+	client := instance.Client()
+	if client == nil {
+		return nil, errdefs.ErrUnavailable.WithMessage("sandbox client is unavailable")
+	}
+
+	return client, nil
 }
 
 func (s *localsandbox) StartStream(ctx context.Context, streamID string) (net.Conn, error) {
+	instance, err := s.activeInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.StartStream(ctx, streamID)
+}
+
+// beginStopping validates that the sandbox can be stopped, marks it
+// stopping, and hands back the instance that is to be shut down.
+func (s *localsandbox) beginStopping() (vm.Instance, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.instance == nil {
-		return nil, fmt.Errorf("sandbox must be started: %w", errdefs.ErrFailedPrecondition)
+		return nil, errdefs.ErrFailedPrecondition.WithMessage("sandbox must be started")
+	}
+	if s.stopping {
+		return nil, errdefs.ErrFailedPrecondition.WithMessage("sandbox is already stopping")
+	}
+	s.stopping = true
+	return s.instance, nil
+}
+
+// activeInstance hands back an instance that has been started and is
+// not begun any shutdown process.
+func (s *localsandbox) activeInstance() (vm.Instance, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.instance == nil {
+		return nil, errdefs.ErrFailedPrecondition.WithMessage("sandbox must be started")
+	}
+	if s.stopping {
+		return nil, errdefs.ErrFailedPrecondition.WithMessage("sandbox is stopping")
 	}
 
-	return s.instance.StartStream(ctx, streamID)
+	return s.instance, nil
 }

--- a/internal/shim/sandbox/vm/vm_test.go
+++ b/internal/shim/sandbox/vm/vm_test.go
@@ -1,0 +1,221 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package vm
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/nerdbox/pkg/vm"
+)
+
+// blockingInstance is a fake vm.Instance whose StartStream and Shutdown
+// block until the test releases them, simulating a guest that never acks
+// the stream handshake, or a shutdown that hangs on an unresponsive guest.
+type blockingInstance struct {
+	vm.Instance
+	startStreamCalled chan struct{}
+	shutdownCalled    chan struct{}
+	release           chan struct{}
+	releaseOnce       sync.Once
+}
+
+// closeRelease is registered via t.Cleanup so a t.Fatal before the
+// normal close doesn't leave a goroutine parked on b.release forever,
+// hanging the rest of the test run.
+func (b *blockingInstance) closeRelease() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+func (b *blockingInstance) StartStream(ctx context.Context, streamID string, opts ...vm.StreamOpt) (net.Conn, error) {
+	close(b.startStreamCalled)
+	<-b.release
+	return nil, nil
+}
+
+func (b *blockingInstance) Shutdown(ctx context.Context) error {
+	close(b.shutdownCalled)
+	<-b.release
+	return nil
+}
+
+func (b *blockingInstance) Client() *ttrpc.Client {
+	return &ttrpc.Client{}
+}
+
+func TestStartStreamDoesNotBlockClient(t *testing.T) {
+	inst := &blockingInstance{
+		startStreamCalled: make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	t.Cleanup(inst.closeRelease)
+	s := &localsandbox{instance: inst}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.StartStream(context.Background(), "test-stream")
+		done <- err
+	}()
+
+	select {
+	case <-inst.startStreamCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartStream was never called on the instance")
+	}
+
+	clientDone := make(chan struct{})
+	go func() {
+		if _, err := s.Client(); err != nil {
+			t.Errorf("Client() returned error: %v", err)
+		}
+		close(clientDone)
+	}()
+
+	select {
+	case <-clientDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Client() blocked behind an in-flight StartStream handshake")
+	}
+
+	inst.closeRelease()
+	if err := <-done; err != nil {
+		t.Fatalf("StartStream returned error: %v", err)
+	}
+}
+
+func TestStopDoesNotBlockClient(t *testing.T) {
+	inst := &blockingInstance{
+		shutdownCalled: make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	t.Cleanup(inst.closeRelease)
+	s := &localsandbox{instance: inst}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Stop(context.Background())
+	}()
+
+	select {
+	case <-inst.shutdownCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown was never called on the instance")
+	}
+
+	clientDone := make(chan struct{})
+	go func() {
+		if _, err := s.Client(); err == nil {
+			t.Error("Client() should fail fast once Stop has begun, not succeed")
+		}
+		close(clientDone)
+	}()
+
+	select {
+	case <-clientDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Client() blocked behind an in-flight Shutdown")
+	}
+
+	inst.closeRelease()
+	if err := <-done; err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+
+	if _, err := s.Client(); err == nil {
+		t.Fatal("Client() should fail after Stop clears the instance")
+	}
+}
+
+// TestConcurrentStopFailsFast verifies that a second Stop call made while
+// the first is still in Shutdown fails immediately with a precondition
+// error instead of racing into a second Shutdown call on the same
+// instance.
+func TestConcurrentStopFailsFast(t *testing.T) {
+	inst := &blockingInstance{
+		shutdownCalled: make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	t.Cleanup(inst.closeRelease)
+	s := &localsandbox{instance: inst}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Stop(context.Background())
+	}()
+
+	select {
+	case <-inst.shutdownCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown was never called on the instance")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- s.Stop(context.Background())
+	}()
+
+	select {
+	case err := <-secondDone:
+		if err == nil {
+			t.Fatal("second concurrent Stop() should have failed instead of racing into Shutdown")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second concurrent Stop() blocked instead of failing fast")
+	}
+
+	inst.closeRelease()
+	if err := <-done; err != nil {
+		t.Fatalf("first Stop returned error: %v", err)
+	}
+}
+
+// TestStartStreamFailsFastWhileStopping verifies that StartStream rejects
+// new streams once Stop has begun tearing down the instance, instead of
+// racing a new stream handshake against a concurrent Shutdown.
+func TestStartStreamFailsFastWhileStopping(t *testing.T) {
+	inst := &blockingInstance{
+		shutdownCalled: make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	t.Cleanup(inst.closeRelease)
+	s := &localsandbox{instance: inst}
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- s.Stop(context.Background())
+	}()
+
+	select {
+	case <-inst.shutdownCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown was never called on the instance")
+	}
+
+	if _, err := s.StartStream(context.Background(), "test-stream"); err == nil {
+		t.Fatal("StartStream() should fail fast once Stop has begun")
+	}
+
+	inst.closeRelease()
+	if err := <-stopDone; err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+}

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -155,13 +155,14 @@ func (*vmManager) NewInstance(ctx context.Context, state string) (vm.Instance, e
 	}
 
 	return &vmInstance{
-		vmc:        vmc,
-		state:      state,
-		kernelPath: kernelPath,
-		rootfsPath: rootfsPath,
-		streamPath: filepath.Join(state, "streaming.sock"),
-		lib:        lib,
-		handler:    handler,
+		vmc:                vmc,
+		state:              state,
+		kernelPath:         kernelPath,
+		rootfsPath:         rootfsPath,
+		streamPath:         filepath.Join(state, "streaming.sock"),
+		lib:                lib,
+		handler:            handler,
+		inFlightHandshakes: make(map[net.Conn]struct{}),
 	}, nil
 }
 
@@ -179,6 +180,16 @@ type vmInstance struct {
 
 	client *ttrpc.Client
 	conn   net.Conn // underlying TTRPC connection; closed in Shutdown
+
+	// inFlightHandshakes lets Shutdown close every dialed-but-unclaimed
+	// StartStream connection, so a handshake blocked on a guest that never
+	// acks returns instead of hanging for the VM's lifetime. Shutdown also
+	// nils this out, so a StartStream that dials afterward fails fast
+	// rather than registering a connection nothing will ever close.
+	inFlightHandshakes map[net.Conn]struct{}
+
+	// shuttingDown is set while Shutdown is tearing the instance down.
+	shuttingDown bool
 }
 
 func (v *vmInstance) AddFS(ctx context.Context, tag, mountPath string, opts ...vm.MountOpt) error {
@@ -397,37 +408,101 @@ func (v *vmInstance) StartStream(ctx context.Context, streamID string, _ ...vm.S
 			if err != nil {
 				return nil, fmt.Errorf("failed to connect to stream server: %w", err)
 			}
-			// Write length-prefixed stream ID
-			idBytes := []byte(streamID)
-			if err := binary.Write(conn, binary.BigEndian, uint32(len(idBytes))); err != nil {
+
+			if !v.trackStreamConn(conn) {
+				// Shutdown has already closed every tracked stream
+				// connection and is tearing down (or has torn down) the
+				// VM; don't hand back a connection racing that teardown.
 				conn.Close()
-				return nil, fmt.Errorf("failed to write stream id length: %w", err)
+				return nil, errdefs.ErrUnavailable.WithMessage("vm instance is shutting down")
 			}
-			if _, err := conn.Write(idBytes); err != nil {
+
+			handshakeErr := completeStreamHandshake(conn, streamID)
+			if !v.untrackStreamConn(conn) {
+				// Shutdown's closeStreamConnsLocked ran while the handshake
+				// was in flight (or in the instant after it finished) and
+				// may have closed this exact conn out from under us, even
+				// though handshakeErr came back nil; don't hand back a
+				// connection that could already be dead.
 				conn.Close()
-				return nil, fmt.Errorf("failed to write stream id: %w", err)
+				return nil, errdefs.ErrUnavailable.WithMessage("vm instance is shutting down")
 			}
-			// Wait for ack (length-prefixed string echoed back)
-			var ackLen uint32
-			if err := binary.Read(conn, binary.BigEndian, &ackLen); err != nil {
+			if handshakeErr != nil {
 				conn.Close()
-				return nil, fmt.Errorf("failed to read ack length: %w", err)
-			}
-			ackBytes := make([]byte, ackLen)
-			if _, err := io.ReadFull(conn, ackBytes); err != nil {
-				conn.Close()
-				return nil, fmt.Errorf("failed to read ack: %w", err)
-			}
-			if ack := string(ackBytes); ack != streamID {
-				conn.Close()
-				return nil, fmt.Errorf("stream %q rejected by server: %s", streamID, ack)
+				return nil, handshakeErr
 			}
 
 			return conn, nil
 		}
 		time.Sleep(d)
 	}
-	return nil, fmt.Errorf("timeout waiting for stream server: %w", errdefs.ErrUnavailable)
+	return nil, errdefs.ErrUnavailable.WithMessage("timed out waiting for stream server")
+}
+
+// completeStreamHandshake has no deadline of its own: a caller that wants
+// it to return when the VM goes away must close conn out from under it
+// (see closeStreamConnsLocked), which unblocks the pending Write or Read
+// with an error.
+func completeStreamHandshake(conn net.Conn, streamID string) error {
+	idBytes := []byte(streamID)
+	if err := binary.Write(conn, binary.BigEndian, uint32(len(idBytes))); err != nil {
+		return fmt.Errorf("failed to write stream id length: %w", err)
+	}
+	if _, err := conn.Write(idBytes); err != nil {
+		return fmt.Errorf("failed to write stream id: %w", err)
+	}
+	var ackLen uint32
+	if err := binary.Read(conn, binary.BigEndian, &ackLen); err != nil {
+		return fmt.Errorf("failed to read ack length: %w", err)
+	}
+	ackBytes := make([]byte, ackLen)
+	if _, err := io.ReadFull(conn, ackBytes); err != nil {
+		return fmt.Errorf("failed to read ack: %w", err)
+	}
+	if ack := string(ackBytes); ack != streamID {
+		return fmt.Errorf("stream %q rejected by server: %s", streamID, ack)
+	}
+	return nil
+}
+
+// trackStreamConn registers conn so closeStreamConnsLocked can close it if
+// it is still in flight when the VM is torn down. It returns false once
+// Shutdown has run (or is running), in which case conn was never
+// registered and the caller must close it itself.
+func (v *vmInstance) trackStreamConn(conn net.Conn) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.inFlightHandshakes == nil {
+		return false
+	}
+	v.inFlightHandshakes[conn] = struct{}{}
+	return true
+}
+
+// untrackStreamConn removes conn from the set closeStreamConnsLocked would
+// close, and reports whether conn was still tracked (i.e. Shutdown had not
+// yet run closeStreamConnsLocked as of this call). A false return means
+// Shutdown already ran and cleared the set, so conn may already have been
+// closed even if it was tracked when this call started — the caller must
+// not treat conn as usable in that case.
+func (v *vmInstance) untrackStreamConn(conn net.Conn) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.inFlightHandshakes == nil {
+		return false
+	}
+	delete(v.inFlightHandshakes, conn)
+	return true
+}
+
+// closeStreamConnsLocked lets a StartStream call blocked in
+// completeStreamHandshake return with an error instead of hanging once
+// the VM it depends on is gone. Callers must hold v.mu.
+func (v *vmInstance) closeStreamConnsLocked() {
+	for conn := range v.inFlightHandshakes {
+		conn.Close()
+	}
+	v.inFlightHandshakes = nil
 }
 
 func (v *vmInstance) Client() *ttrpc.Client {
@@ -437,11 +512,22 @@ func (v *vmInstance) Client() *ttrpc.Client {
 }
 
 func (v *vmInstance) Shutdown(ctx context.Context) error {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if v.handler == 0 {
-		return fmt.Errorf("libkrun already closed")
+	err := v.beginShutdown()
+	if err != nil {
+		return err
 	}
+
+	// shuttingDown clears once the teardown below finishes, successfully
+	// or not, so a caller that gets an error back (e.g. from dlClose) can
+	// retry instead of finding this instance permanently stuck rejecting
+	// every Shutdown call.
+	defer func() {
+		v.mu.Lock()
+		v.shuttingDown = false
+		v.mu.Unlock()
+	}()
+
+	v.mu.Lock()
 
 	// Close the TTRPC client so in-flight RPCs fail fast and its background
 	// goroutines are stopped before we tear down the connection underneath.
@@ -460,6 +546,10 @@ func (v *vmInstance) Shutdown(ctx context.Context) error {
 		v.conn = nil
 	}
 
+	// Run the shutdown of the vm context outside of the critical section to
+	// allow concurrent operations to run/stop gracefully.
+	v.mu.Unlock()
+
 	// Stop the VM. krun_free_ctx joins all VM threads (vCPU, virtio workers)
 	// on most platforms. On Windows WHP it initiates the stop but may return
 	// before krun_start_enter unblocks; the goroutine is cleaned up on exit.
@@ -471,10 +561,34 @@ func (v *vmInstance) Shutdown(ctx context.Context) error {
 
 	// On Unix, dlClose unloads the library after krun_free_ctx has joined all
 	// VM threads. On Windows it is a no-op (see dlfcn_windows.go).
-	if err := dlClose(v.handler); err != nil {
+	v.mu.Lock()
+	handler := v.handler
+	v.mu.Unlock()
+
+	if err := dlClose(handler); err != nil {
 		return err
 	}
+
+	v.mu.Lock()
 	v.handler = 0
+	v.mu.Unlock()
+	return nil
+}
+
+// beginShutdown validates the instance can be shutdown and marks it
+// as shutdown in progress to prevent concurrent shutdowns from occurring.
+func (v *vmInstance) beginShutdown() error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.handler == 0 {
+		return errors.New("libkrun already closed")
+	}
+	if v.shuttingDown {
+		return errors.New("libkrun already shutting down")
+	}
+	v.shuttingDown = true
+	v.closeStreamConnsLocked()
 	return nil
 }
 

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -439,6 +439,22 @@ func (v *vmInstance) StartStream(ctx context.Context, streamID string, _ ...vm.S
 	return nil, errdefs.ErrUnavailable.WithMessage("timed out waiting for stream server")
 }
 
+// maxAckSize bounds the length-prefixed ack completeStreamHandshake will
+// allocate for, relative to idLen (the stream ID's length). ackLen is
+// guest-controlled, so the bound can't be a fixed constant: the streaming
+// protocol documents IDs as arbitrary strings, and the guest's success ack
+// is the ID itself (plugins/vminit/streaming/plugin.go:152-154), so a
+// fixed cap would reject legitimate IDs above it after the guest already
+// accepted them. The guest's only other response is a short %q-wrapped
+// rejection message naming the ID (same file); Go's %q quoting can expand
+// a single byte needing a \xHH escape into 4 output characters, so the
+// bound scales by 4x (not 2x) plus a fixed margin for the surrounding
+// quotes and message text, while still bounding what an adversarial guest
+// can force to a small multiple of what the caller itself sent.
+func maxAckSize(idLen int) int {
+	return 4*idLen + 64
+}
+
 // completeStreamHandshake has no deadline of its own: a caller that wants
 // it to return when the VM goes away must close conn out from under it
 // (see closeStreamConnsLocked), which unblocks the pending Write or Read
@@ -454,6 +470,9 @@ func completeStreamHandshake(conn net.Conn, streamID string) error {
 	var ackLen uint32
 	if err := binary.Read(conn, binary.BigEndian, &ackLen); err != nil {
 		return fmt.Errorf("failed to read ack length: %w", err)
+	}
+	if max := maxAckSize(len(idBytes)); ackLen > uint32(max) {
+		return fmt.Errorf("ack length %d exceeds maximum %d for a %d-byte stream id", ackLen, max, len(idBytes))
 	}
 	ackBytes := make([]byte, ackLen)
 	if _, err := io.ReadFull(conn, ackBytes); err != nil {

--- a/internal/vm/libkrun/instance.go
+++ b/internal/vm/libkrun/instance.go
@@ -417,19 +417,46 @@ func (v *vmInstance) StartStream(ctx context.Context, streamID string, _ ...vm.S
 				return nil, errdefs.ErrUnavailable.WithMessage("vm instance is shutting down")
 			}
 
-			handshakeErr := completeStreamHandshake(conn, streamID)
-			if !v.untrackStreamConn(conn) {
-				// Shutdown's closeStreamConnsLocked ran while the handshake
-				// was in flight (or in the instant after it finished) and
-				// may have closed this exact conn out from under us, even
-				// though handshakeErr came back nil; don't hand back a
-				// connection that could already be dead.
-				conn.Close()
-				return nil, errdefs.ErrUnavailable.WithMessage("vm instance is shutting down")
+			// completeStreamHandshake has no deadline of its own, and
+			// closeStreamConnsLocked only unblocks it once Shutdown runs.
+			// A guest that stops acking streams while the VM keeps running
+			// would otherwise wedge this call for the VM's lifetime, so
+			// bound it here too.
+			deadline := time.Now().Add(vmStartTimeout)
+			if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+				deadline = dl
 			}
+			if err := conn.SetDeadline(deadline); err != nil {
+				v.untrackStreamConn(conn)
+				conn.Close()
+				return nil, fmt.Errorf("failed to set stream handshake deadline: %w", err)
+			}
+
+			handshakeErr := completeStreamHandshake(conn, streamID)
 			if handshakeErr != nil {
+				v.untrackStreamConn(conn)
 				conn.Close()
 				return nil, handshakeErr
+			}
+
+			// Clear the deadline before the untrack check below: it
+			// becomes a long-lived I/O stream from here, not bounded by
+			// vmStartTimeout, but conn must stay tracked while this can
+			// still fail.
+			if err := conn.SetDeadline(time.Time{}); err != nil {
+				v.untrackStreamConn(conn)
+				conn.Close()
+				return nil, fmt.Errorf("failed to clear stream handshake deadline: %w", err)
+			}
+
+			// Untrack as the last check before returning conn: keeping it
+			// tracked until here means Shutdown, if it runs anywhere
+			// during the handshake or the deadline clear above, still
+			// finds and closes conn instead of this call handing back a
+			// connection racing (or already lost to) that teardown.
+			if !v.untrackStreamConn(conn) {
+				conn.Close()
+				return nil, errdefs.ErrUnavailable.WithMessage("vm instance is shutting down")
 			}
 
 			return conn, nil

--- a/internal/vm/libkrun/instance_test.go
+++ b/internal/vm/libkrun/instance_test.go
@@ -207,3 +207,62 @@ func TestCompleteStreamHandshakeAcceptsLongStreamID(t *testing.T) {
 		t.Fatal("completeStreamHandshake did not return for a long stream id")
 	}
 }
+
+// withShortVMStartTimeout temporarily shortens the package-level
+// vmStartTimeout, restoring it via t.Cleanup.
+func withShortVMStartTimeout(t *testing.T, d time.Duration) {
+	old := vmStartTimeout
+	vmStartTimeout = d
+	t.Cleanup(func() { vmStartTimeout = old })
+}
+
+// TestStartStreamHandshakeIsBounded verifies that a guest which accepts a
+// stream but never acks it cannot wedge StartStream for as long as the VM
+// keeps running: closeStreamConnsLocked only unblocks a handshake once
+// Shutdown runs, so this guest, with no Shutdown ever called, can only be
+// bounded by StartStream's own deadline.
+func TestStartStreamHandshakeIsBounded(t *testing.T) {
+	withShortVMStartTimeout(t, 200*time.Millisecond)
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) })
+
+	const streamPath = "streaming.sock"
+	l, err := net.Listen("unix", streamPath)
+	if err != nil {
+		t.Fatalf("failed to listen on %s: %v", streamPath, err)
+	}
+	defer l.Close()
+
+	hang := make(chan struct{})
+	t.Cleanup(func() { close(hang) })
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var idLen uint32
+		if err := binary.Read(conn, binary.BigEndian, &idLen); err != nil {
+			return
+		}
+		io.ReadFull(conn, make([]byte, idLen))
+		<-hang // Deliberately never acks.
+	}()
+
+	v := &vmInstance{streamPath: streamPath, inFlightHandshakes: make(map[net.Conn]struct{})}
+
+	start := time.Now()
+	if _, err := v.StartStream(context.Background(), "test-stream"); err == nil {
+		t.Fatal("expected an error from a guest that never acks")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("StartStream took %s to fail, want about %s", elapsed, vmStartTimeout)
+	}
+}

--- a/internal/vm/libkrun/instance_test.go
+++ b/internal/vm/libkrun/instance_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -127,5 +128,82 @@ func TestStartStreamFailsFastOnceShutdown(t *testing.T) {
 	defer cancel()
 	if _, err := v.StartStream(ctx, "test-stream"); err == nil {
 		t.Fatal("expected StartStream to fail fast once inFlightHandshakes is nil")
+	}
+}
+
+// TestCompleteStreamHandshakeRejectsOversizedAck verifies that a
+// guest-claimed ack length far larger than the stream ID sent is rejected
+// before completeStreamHandshake allocates a buffer for it, so a
+// malicious or buggy guest can't force an arbitrarily large allocation
+// with a single crafted length prefix.
+func TestCompleteStreamHandshakeRejectsOversizedAck(t *testing.T) {
+	const streamID = "test-stream"
+
+	guestConn, hostConn := net.Pipe()
+	defer guestConn.Close()
+
+	go func() {
+		var idLen uint32
+		if err := binary.Read(guestConn, binary.BigEndian, &idLen); err != nil {
+			return
+		}
+		io.ReadFull(guestConn, make([]byte, idLen))
+		// Claim an ack far larger than any legitimate response for this ID
+		// instead of echoing the stream ID back.
+		binary.Write(guestConn, binary.BigEndian, uint32(maxAckSize(len(streamID))+1))
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- completeStreamHandshake(hostConn, streamID)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error for an ack length above the maximum for this stream id")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("completeStreamHandshake did not return for an oversized ack length")
+	}
+}
+
+// TestCompleteStreamHandshakeAcceptsLongStreamID verifies that a
+// legitimate stream ID longer than the old fixed ack-size cap still
+// succeeds: the streaming protocol documents stream IDs as arbitrary
+// strings, so the ack bound must scale with the ID's own length instead
+// of rejecting an ID the guest already accepted and echoed back.
+func TestCompleteStreamHandshakeAcceptsLongStreamID(t *testing.T) {
+	streamID := strings.Repeat("x", 8192)
+
+	guestConn, hostConn := net.Pipe()
+	defer guestConn.Close()
+
+	go func() {
+		var idLen uint32
+		if err := binary.Read(guestConn, binary.BigEndian, &idLen); err != nil {
+			return
+		}
+		idBytes := make([]byte, idLen)
+		if _, err := io.ReadFull(guestConn, idBytes); err != nil {
+			return
+		}
+		// Echo the stream ID back verbatim, as a real guest ack does.
+		binary.Write(guestConn, binary.BigEndian, idLen)
+		guestConn.Write(idBytes)
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- completeStreamHandshake(hostConn, streamID)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected a long but legitimate stream id to succeed, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("completeStreamHandshake did not return for a long stream id")
 	}
 }

--- a/internal/vm/libkrun/instance_test.go
+++ b/internal/vm/libkrun/instance_test.go
@@ -1,0 +1,131 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package libkrun
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestStartStreamUnblockedByShutdown verifies that a StartStream call
+// blocked in the guest handshake (waiting for an ack that will never come)
+// returns with an error as soon as its connection is closed the way
+// Shutdown's closeStreamConnsLocked does, instead of hanging forever.
+func TestStartStreamUnblockedByShutdown(t *testing.T) {
+	guestConn, hostConn := net.Pipe()
+	defer guestConn.Close()
+
+	// Simulate a guest that reads the stream ID but never acks it.
+	received := make(chan struct{})
+	go func() {
+		var idLen uint32
+		if err := binary.Read(guestConn, binary.BigEndian, &idLen); err != nil {
+			return
+		}
+		io.ReadFull(guestConn, make([]byte, idLen))
+		close(received)
+		// Deliberately never writes an ack back.
+	}()
+
+	v := &vmInstance{inFlightHandshakes: make(map[net.Conn]struct{})}
+	if !v.trackStreamConn(hostConn) {
+		t.Fatal("trackStreamConn should succeed before Shutdown has run")
+	}
+
+	handshakeDone := make(chan error, 1)
+	go func() {
+		handshakeDone <- completeStreamHandshake(hostConn, "test-stream")
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("guest side never received the stream id")
+	}
+
+	// completeStreamHandshake must now be blocked reading the ack that
+	// will never come. Simulate Shutdown closing every tracked stream
+	// connection.
+	v.mu.Lock()
+	v.closeStreamConnsLocked()
+	v.mu.Unlock()
+
+	select {
+	case err := <-handshakeDone:
+		if err == nil {
+			t.Fatal("expected an error once the connection was closed out from under the handshake")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handshake did not return after its connection was closed")
+	}
+}
+
+// TestStartStreamFailsFastOnceShutdown verifies that StartStream, called
+// after Shutdown has already cleared inFlightHandshakes, fails fast instead of
+// completing a handshake against a VM that is gone.
+func TestStartStreamFailsFastOnceShutdown(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWD) })
+
+	const streamPath = "streaming.sock"
+	l, err := net.Listen("unix", streamPath)
+	if err != nil {
+		t.Fatalf("failed to listen on %s: %v", streamPath, err)
+	}
+	defer l.Close()
+
+	// Accept connections but never respond: if StartStream reached the
+	// handshake, it would hang. It must not get that far. Connections are
+	// collected and closed once the loop exits (listener closed) rather
+	// than via a defer inside the loop, which would stack one deferred
+	// close per accepted connection until the goroutine returns anyway.
+	go func() {
+		var conns []net.Conn
+		defer func() {
+			for _, c := range conns {
+				c.Close()
+			}
+		}()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			conns = append(conns, conn)
+		}
+	}()
+
+	// inFlightHandshakes is left nil, matching the post-Shutdown state.
+	v := &vmInstance{streamPath: streamPath}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := v.StartStream(ctx, "test-stream"); err == nil {
+		t.Fatal("expected StartStream to fail fast once inFlightHandshakes is nil")
+	}
+}


### PR DESCRIPTION
localsandbox serialized every RPC behind one mutex, including two calls
with no deadline of their own: Stop's call into instance.Shutdown and
StartStream's guest handshake. A guest that stopped acking streams, or a
slow Shutdown, held that mutex for as long as the stall lasted, blocking
every other RPC against the sandbox. The same problem existed one layer
down in the libkrun vm.Instance: StartStream shared no lock with Shutdown
at all, and its handshake had no deadline, so a stalled guest could wedge
an individual exec for the VM's lifetime even once the sandbox-level fix
stopped it from blocking unrelated RPCs.

This change, across four commits:

- Releases localsandbox's s.mu before the blocking calls in Stop and
  StartStream, holding it only to read/mutate localsandbox's own state.
  A stopping flag makes concurrent Stop calls fail fast instead of
  racing each other, and makes Client/StartStream fail fast instead of
  racing a call against an in-flight Shutdown. Client also now rejects a
  nil client from the instance as unavailable, rather than silently
  returning (nil, nil).
- Has the libkrun vm.Instance track in-flight StartStream handshakes so
  Shutdown can close them, unblocking a handshake stalled on a guest
  that never acks instead of leaving it to hang for the life of the VM.
  A shuttingDown flag serializes concurrent Shutdown calls and lets
  Shutdown release its own lock before the unbounded VM teardown.
- Bounds the handshake's ack read relative to the stream ID's length,
  closing a guest-controlled unbounded-allocation path.
- Bounds the handshake itself with a deadline (min of an internal
  timeout and the caller's context deadline), and separately watches
  for context cancellation without a deadline (e.g. a disconnected
  ttrpc request), so a wedged guest or a canceled caller can no longer
  hold a stream handshake open indefinitely.

Tested with `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test`
on both changed packages; each fix has a dedicated regression test
verified against a temporarily reverted version of the fix.